### PR TITLE
Fix bug with hanging app on startup

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -155,11 +155,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e0306e92cef41d02af05a9f88395ec49c94f0255d54ca88ee3c02ae8f5806ee3"
+  digest = "1:7c71e4035e802da25ad590ae5f1cb0e931b2b4806aa0b5539d53c02a1cf6a64d"
   name = "github.com/jesseduffield/termbox-go"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "a9796224c07f5d757b399082bfee60de9574a2d9"
+  revision = "9dd53af7214ead48bbe380cdf8a3229ec43eeb58"
 
 [[projects]]
   branch = "v2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,3 @@
 [[constraint]]
   branch = "v2"
   name = "github.com/jesseduffield/yaml"
-
-[[constraint]]
-  branch = "master"
-  name = "github.com/jesseduffield/roll"

--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -370,6 +370,10 @@ func (c *OSCommand) PipeCommands(commandStrings ...string) error {
 
 // Kill kills a process. If the process has Setpgid == true, then we have anticipated that it might spawn its own child processes, so we've given it a process group ID (PGID) equal to its process id (PID) and given its child processes will inherit the PGID, we can kill that group, rather than killing the process itself.
 func (c *OSCommand) Kill(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		// somebody got to it before we were able to, poor bastard
+		return nil
+	}
 	if cmd.SysProcAttr != nil && cmd.SysProcAttr.Setpgid == true {
 		// minus sign means we're talking about a PGID as opposed to a PID
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)

--- a/pkg/gui/containers_panel.go
+++ b/pkg/gui/containers_panel.go
@@ -193,7 +193,9 @@ func (gui *Gui) renderContainerLogs(container *commands.Container) error {
 
 		go func() {
 			<-stop
-			cmd.Process.Kill()
+			if err := gui.OSCommand.Kill(cmd); err != nil {
+				gui.Log.Warn(err)
+			}
 			gui.Log.Info("killed container logs process")
 			return
 		}()

--- a/vendor/github.com/jesseduffield/termbox-go/api.go
+++ b/vendor/github.com/jesseduffield/termbox-go/api.go
@@ -22,6 +22,8 @@ import "time"
 //      }
 //      defer termbox.Close()
 func Init() error {
+	quitPolling = make(chan int)
+
 	var err error
 
 	out, err = os.OpenFile("/dev/tty", syscall.O_WRONLY, 0)
@@ -120,7 +122,7 @@ func Interrupt() {
 // when termbox's functionality isn't required anymore.
 func Close() {
 	quit <- 1
-	quitPolling <- 1
+	close(quitPolling)
 	out.WriteString(funcs[t_show_cursor])
 	out.WriteString(funcs[t_sgr0])
 	out.WriteString(funcs[t_clear_screen])

--- a/vendor/github.com/jesseduffield/termbox-go/termbox.go
+++ b/vendor/github.com/jesseduffield/termbox-go/termbox.go
@@ -77,7 +77,7 @@ var (
 	sigwinch       = make(chan os.Signal, 1)
 	sigio          = make(chan os.Signal, 1)
 	quit           = make(chan int)
-	quitPolling    = make(chan int)
+	quitPolling    chan int // get set on each initialize
 	input_comm     = make(chan input_event)
 	interrupt_comm = make(chan struct{})
 	intbuf         = make([]byte, 0, 16)


### PR DESCRIPTION
This PR kills two birds with one stone. 
bird #1: the app hanging when the docker daemon was not set (actually happened whenever there was an error before the gui started polling events)
bird #2: the process kill function now checks to see if the process is actually there before trying to kill it 