### PR TITLE
support light themes in terminals

### DIFF
--- a/pkg/commands/container.go
+++ b/pkg/commands/container.go
@@ -245,7 +245,7 @@ type ContainerCliStat struct {
 
 // GetDisplayStrings returns the dispaly string of Container
 func (c *Container) GetDisplayStrings(isFocused bool) []string {
-	return []string{c.GetDisplayStatus(), utils.ColoredString(c.Name, color.FgWhite), c.GetDisplayCPUPerc()}
+	return []string{c.GetDisplayStatus(), c.Name, c.GetDisplayCPUPerc()}
 }
 
 // GetDisplayStatus returns the colored status of the container

--- a/pkg/commands/image.go
+++ b/pkg/commands/image.go
@@ -27,7 +27,7 @@ type Image struct {
 // GetDisplayStrings returns the display string of Image
 func (i *Image) GetDisplayStrings(isFocused bool) []string {
 
-	return []string{utils.ColoredString(i.Name, color.FgWhite), utils.ColoredString(i.Tag, color.FgWhite), utils.FormatDecimalBytes(int(i.Image.Size))}
+	return []string{i.Name, i.Tag, utils.FormatDecimalBytes(int(i.Image.Size))}
 }
 
 // Remove removes the image

--- a/pkg/commands/service.go
+++ b/pkg/commands/service.go
@@ -23,11 +23,11 @@ type Service struct {
 func (s *Service) GetDisplayStrings(isFocused bool) []string {
 
 	if s.Container == nil {
-		return []string{utils.ColoredString("none", color.FgBlack), utils.ColoredString(s.Name, color.FgWhite), ""}
+		return []string{utils.ColoredString("none", color.FgBlack), s.Name, ""}
 	}
 
 	cont := s.Container
-	return []string{cont.GetDisplayStatus(), utils.ColoredString(s.Name, color.FgWhite), cont.GetDisplayCPUPerc()}
+	return []string{cont.GetDisplayStatus(), s.Name, cont.GetDisplayCPUPerc()}
 }
 
 // Remove removes the service's containers

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -170,7 +170,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 			return err
 		}
 		v.Wrap = gui.Config.UserConfig.Gui.WrapMainPanel
-		v.FgColor = gocui.ColorWhite
+		v.FgColor = gocui.ColorDefault
 
 		// when you run a docker container with the -it flags (interactive mode) it adds carriage returns for some reason. This is not docker's fault, it's an os-level default.
 		v.IgnoreCarriageReturns = true
@@ -181,7 +181,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 			return err
 		}
 		v.Title = gui.Tr.StatusTitle
-		v.FgColor = gocui.ColorWhite
+		v.FgColor = gocui.ColorDefault
 	}
 
 	var servicesView *gocui.View
@@ -195,7 +195,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 			}
 			servicesView.Highlight = true
 			servicesView.Title = gui.Tr.ServicesTitle
-			servicesView.FgColor = gocui.ColorWhite
+			servicesView.FgColor = gocui.ColorDefault
 		}
 	}
 
@@ -210,7 +210,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		} else {
 			containersView.Title = gui.Tr.StandaloneContainersTitle
 		}
-		containersView.FgColor = gocui.ColorWhite
+		containersView.FgColor = gocui.ColorDefault
 	}
 
 	imagesView, err := g.SetViewBeneath("images", "containers", vHeights["images"])
@@ -220,7 +220,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		}
 		imagesView.Highlight = true
 		imagesView.Title = gui.Tr.ImagesTitle
-		imagesView.FgColor = gocui.ColorWhite
+		imagesView.FgColor = gocui.ColorDefault
 	}
 
 	volumesView, err := g.SetViewBeneath("volumes", "images", vHeights["volumes"])
@@ -230,7 +230,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		}
 		volumesView.Highlight = true
 		volumesView.Title = gui.Tr.VolumesTitle
-		volumesView.FgColor = gocui.ColorWhite
+		volumesView.FgColor = gocui.ColorDefault
 	}
 
 	if v, err := g.SetView("options", appStatusOptionsBoundary-1, height-2, optionsVersionBoundary-1, height, 0); err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -45,6 +45,10 @@ func WithPadding(str string, padding int) string {
 // ColoredString takes a string and a colour attribute and returns a colored
 // string with that attribute
 func ColoredString(str string, colorAttribute color.Attribute) string {
+	// fatih/color does not have a color.Default attribute, so unless we fork that repo the only way for us to express that we don't want to color a string different to the terminal's default is to not call the function in the first place, but that's annoying when you want a streamlined code path. Because I'm too lazy to fork the repo right now, we'll just assume that by FgWhite you really mean Default, for the sake of supporting users with light themed terminals.
+	if colorAttribute == color.FgWhite {
+		return str
+	}
 	colour := color.New(colorAttribute)
 	return ColoredStringDirect(str, colour)
 }
@@ -371,7 +375,7 @@ func WithShortSha(str string) string {
 
 // FormatMapItem is for displaying items in a map
 func FormatMapItem(padding int, k string, v interface{}) string {
-	return fmt.Sprintf("%s%s %v\n", strings.Repeat(" ", padding), ColoredString(k+":", color.FgYellow), ColoredString(fmt.Sprintf("%v", v), color.FgWhite))
+	return fmt.Sprintf("%s%s %v\n", strings.Repeat(" ", padding), ColoredString(k+":", color.FgYellow), fmt.Sprintf("%v", v))
 }
 
 // FormatMap is for displaying a map


### PR DESCRIPTION
main crux for this one is that we have no way of differentiating color.FgWhite from something like color.Default because the fatih/color repo doesn't have a concept of default, unlike termbox. So for now we're just treating FgWhite as default in our color util functions by just returning the string as-is