### PR TITLE
Tweak installation instructions when using Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ required go version: 1.12
 
 ```sh
 go get github.com/jesseduffield/lazydocker
+go install github.com/jesseduffield/lazydocker
+
+# add your go workspace bin directory to your path (you may want to do this in a shell profile):
+export PATH=$PATH:$(go env GOPATH)/bin
 ```
 
 ## Usage


### PR DESCRIPTION
The installation instructions when using Go to grab the code were missing the key `go install` step. I've added this to the readme, as well as pointed out that adding the go workspace bin path to your profile may be desirable.

Cool project, thanks for your work on it! :+1: 