### PR TITLE
fix strings.ReplaceAll() does't exist error while go version bellow 1.12

### DIFF
--- a/pkg/commands/image.go
+++ b/pkg/commands/image.go
@@ -68,7 +68,7 @@ func (l *Layer) GetDisplayStrings(isFocused bool) []string {
 		createdBy = utils.ColoredString(split[0], color.FgYellow) + " " + strings.Join(split[1:], " ")
 	}
 
-	createdBy = strings.ReplaceAll(createdBy, "\t", " ")
+	createdBy = strings.Replace(createdBy, "\t", " ", -1)
 
 	size := utils.FormatBinaryBytes(int(l.Size))
 	sizeColor := color.FgWhite


### PR DESCRIPTION
### reason
I also got strings.ReplaceAll does't exist error while go get so i want fix it

### version
- go 1.11.9 linux/amd64
- docker 18.06.1-ce

### issue
#13 

### solution
use strings.Replace() instead
