### PR TITLE
Reworked Dockerfile for a more production oriented usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.circleci
+.github
+docs
+test
+.gitignore
+.goreleaser.yml
+*.md
+coverage.txt
+Dockerfile
+LICENSE
+test.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ coverage.txt
 Dockerfile
 LICENSE
 test.sh
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,5 @@ LABEL org.label-schema.schema-version="1.0.0-rc1" \
     org.label-schema.vcs-description="The lazier way to manage everything docker" \
     org.label-schema.docker.cmd="docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazydocker" \
     org.label-schema.version=${VERSION}
-RUN apk --update add -q --progress --no-cache -U git xdg-utils
-ENTRYPOINT [ "lazydocker" ]
+ENTRYPOINT [ "/bin/sh" ]
 COPY --from=builder /go/src/github.com/jesseduffield/lazydocker/lazydocker /usr/bin/lazydocker

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,5 @@ LABEL org.label-schema.schema-version="1.0.0-rc1" \
     org.label-schema.docker.cmd="docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazydocker" \
     org.label-schema.version=${VERSION}
 ENTRYPOINT [ "/lazydocker" ]
+VOLUME [ "/.config/jesseduffield/lazydocker" ]
 COPY --from=builder /go/src/github.com/jesseduffield/lazydocker/lazydocker /lazydocker

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,24 @@ ARG GO_VERSION=1.12.6
 FROM ${BASE_IMAGE_BUILDER}:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 ARG GOARCH=amd64
 ARG GOARM
+ARG VERSION=0.2.4
+RUN apk --update add -q --progress git
 WORKDIR /go/src/github.com/jesseduffield/lazydocker/
 COPY ./ .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} go build -a -installsuffix cgo -ldflags="-s -w"
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} go build -a -installsuffix cgo -ldflags="-s -w \
+    -X main.commit=$(git rev-parse HEAD) \
+    -X main.version=${VERSION} \
+    -X main.buildSource=Docker"
 
 FROM ${BASE_IMAGE}:${ALPINE_VERSION}
+ARG VERSION=0.2.4
+LABEL org.label-schema.schema-version="1.0.0-rc1" \
+    maintainer="jessedduffield@gmail.com" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.url="https://github.com/jesseduffield/lazydocker" \
+    org.label-schema.vcs-description="The lazier way to manage everything docker" \
+    org.label-schema.docker.cmd="docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazydocker" \
+    org.label-schema.version=${VERSION}
 RUN apk --update add -q --progress --no-cache -U git xdg-utils
 ENTRYPOINT [ "lazydocker" ]
 COPY --from=builder /go/src/github.com/jesseduffield/lazydocker/lazydocker /usr/bin/lazydocker

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG VERSION
 ARG VCS_REF
 WORKDIR /go/src/github.com/jesseduffield/lazydocker/
 COPY ./ .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} go build -a -installsuffix cgo -ldflags="-s -w \
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} go build -a -ldflags="-s -w \
     -X main.commit=${VCS_REF} \
     -X main.version=${VERSION} \
     -X main.buildSource=Docker"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ARG GO_VERSION=1.12.6
 FROM ${BASE_IMAGE_BUILDER}:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 ARG GOARCH=amd64
 ARG GOARM
-ARG VERSION=0.2.4
-ARG VCS_REF=
+ARG VERSION
+ARG VCS_REF
 WORKDIR /go/src/github.com/jesseduffield/lazydocker/
 COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} go build -a -installsuffix cgo -ldflags="-s -w \
@@ -16,8 +16,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} go build -a -instal
     -X main.buildSource=Docker"
 
 FROM ${BASE_IMAGE}:${ALPINE_VERSION}
-ARG VERSION=0.2.4
-ARG VCS_REF=
+ARG VERSION
+ARG VCS_REF
 LABEL org.label-schema.schema-version="1.0.0-rc1" \
     maintainer="jessedduffield@gmail.com" \
     org.label-schema.vcs-ref=$VCS_REF \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,11 @@ ARG GOARCH=amd64
 ARG GOARM
 ARG VERSION
 ARG VCS_REF
-WORKDIR /go/src/github.com/jesseduffield/lazydocker/
+WORKDIR /tmp/gobuild
 COPY ./ .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} go build -a -ldflags="-s -w \
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} \
+    go build -a -mod=vendor \
+    -ldflags="-s -w \
     -X main.commit=${VCS_REF} \
     -X main.version=${VERSION} \
     -X main.buildSource=Docker"
@@ -43,5 +45,5 @@ LABEL org.label-schema.schema-version="1.0.0-rc1" \
 ENTRYPOINT [ "/bin/lazydocker" ]
 VOLUME [ "/.config/jesseduffield/lazydocker" ]
 ENV PATH=/bin
-COPY --from=builder /go/src/github.com/jesseduffield/lazydocker/lazydocker /bin/lazydocker
 COPY --from=docker-builder /go/src/github.com/docker/cli/build/docker /bin/docker
+COPY --from=builder /tmp/gobuild/lazydocker /bin/lazydocker

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,5 @@ LABEL \
     org.opencontainers.image.title="lazydocker" \
     org.opencontainers.image.description="The lazier way to manage everything docker"
 ENTRYPOINT [ "/bin/lazydocker" ]
-ENV PATH=/bin
 COPY --from=docker-builder /go/src/github.com/docker/cli/build/docker /bin/docker
 COPY --from=builder /tmp/gobuild/lazydocker /bin/lazydocker

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,6 @@ LABEL org.label-schema.schema-version="1.0.0-rc1" \
     org.label-schema.vcs-description="The lazier way to manage everything docker" \
     org.label-schema.docker.cmd="docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazydocker" \
     org.label-schema.version=${VERSION}
-ENTRYPOINT [ "/bin/sh" ]
+RUN printf "#!/bin/sh\n\nresize > /dev/null\nlazydocker \$@\n" > /usr/bin/run && chmod 500 /usr/bin/run
+ENTRYPOINT [ "/usr/bin/run" ]
 COPY --from=builder /go/src/github.com/jesseduffield/lazydocker/lazydocker /usr/bin/lazydocker

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ LABEL org.label-schema.schema-version="1.0.0-rc1" \
     org.label-schema.vcs-description="The lazier way to manage everything docker" \
     org.label-schema.docker.cmd="docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazydocker" \
     org.label-schema.version=${VERSION}
-ENTRYPOINT [ "/lazydocker" ]
+ENTRYPOINT [ "/bin/lazydocker" ]
 VOLUME [ "/.config/jesseduffield/lazydocker" ]
-ENV PATH=/
-COPY --from=docker-builder /go/src/github.com/docker/cli/build/docker /docker
+ENV PATH=/bin
+COPY --from=builder /go/src/github.com/jesseduffield/lazydocker/lazydocker /bin/lazydocker
+COPY --from=docker-builder /go/src/github.com/docker/cli/build/docker /bin/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,17 @@ FROM ${BASE_IMAGE_BUILDER}:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 ARG GOARCH=amd64
 ARG GOARM
 ARG VERSION=0.2.4
-RUN apk --update add -q --progress git
+ARG VCS_REF=
 WORKDIR /go/src/github.com/jesseduffield/lazydocker/
 COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} go build -a -installsuffix cgo -ldflags="-s -w \
-    -X main.commit=$(git rev-parse HEAD) \
+    -X main.commit=${VCS_REF} \
     -X main.version=${VERSION} \
     -X main.buildSource=Docker"
 
 FROM ${BASE_IMAGE}:${ALPINE_VERSION}
 ARG VERSION=0.2.4
+ARG VCS_REF=
 LABEL org.label-schema.schema-version="1.0.0-rc1" \
     maintainer="jessedduffield@gmail.com" \
     org.label-schema.vcs-ref=$VCS_REF \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 ARG BASE_IMAGE_BUILDER=golang
-ARG BASE_IMAGE=alpine
 ARG ALPINE_VERSION=3.10
 ARG GO_VERSION=1.12.6
 
@@ -15,16 +14,17 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} go build -a -instal
     -X main.version=${VERSION} \
     -X main.buildSource=Docker"
 
-FROM ${BASE_IMAGE}:${ALPINE_VERSION}
-ARG VERSION
+FROM scratch
+ARG BUILD_DATE
 ARG VCS_REF
+ARG VERSION
 LABEL org.label-schema.schema-version="1.0.0-rc1" \
     maintainer="jessedduffield@gmail.com" \
+    org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.url="https://github.com/jesseduffield/lazydocker" \
     org.label-schema.vcs-description="The lazier way to manage everything docker" \
     org.label-schema.docker.cmd="docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazydocker" \
     org.label-schema.version=${VERSION}
-RUN printf "#!/bin/sh\n\nresize > /dev/null\nlazydocker \$@\n" > /usr/bin/run && chmod 500 /usr/bin/run
-ENTRYPOINT [ "/usr/bin/run" ]
-COPY --from=builder /go/src/github.com/jesseduffield/lazydocker/lazydocker /usr/bin/lazydocker
+ENTRYPOINT [ "/lazydocker" ]
+COPY --from=builder /go/src/github.com/jesseduffield/lazydocker/lazydocker /lazydocker

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,20 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} go build -a -ldflag
     -X main.version=${VERSION} \
     -X main.buildSource=Docker"
 
+FROM ${BASE_IMAGE_BUILDER}:${GO_VERSION}-alpine${ALPINE_VERSION} AS docker-builder
+ARG GOARCH=amd64
+ARG GOARM
+ARG DOCKER_VERSION=v18.09.7
+RUN apk add -U -q --progress --no-cache git bash coreutils gcc musl-dev
+WORKDIR /go/src/github.com/docker/cli
+RUN git clone --branch ${DOCKER_VERSION} --single-branch --depth 1 https://github.com/docker/cli.git . > /dev/null 2>&1
+ENV CGO_ENABLED=0 \
+    GOARCH=${GOARCH} \
+    GOARM=${GOARM} \
+    DISABLE_WARN_OUTSIDE_CONTAINER=1
+RUN ./scripts/build/binary
+RUN rm build/docker && mv build/docker-linux-* build/docker
+
 FROM scratch
 ARG BUILD_DATE
 ARG VCS_REF
@@ -28,4 +42,5 @@ LABEL org.label-schema.schema-version="1.0.0-rc1" \
     org.label-schema.version=${VERSION}
 ENTRYPOINT [ "/lazydocker" ]
 VOLUME [ "/.config/jesseduffield/lazydocker" ]
-COPY --from=builder /go/src/github.com/jesseduffield/lazydocker/lazydocker /lazydocker
+ENV PATH=/
+COPY --from=docker-builder /go/src/github.com/docker/cli/build/docker /docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ LABEL org.label-schema.schema-version="1.0.0-rc1" \
     org.label-schema.docker.cmd="docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazydocker" \
     org.label-schema.version=${VERSION}
 ENTRYPOINT [ "/bin/lazydocker" ]
-VOLUME [ "/.config/jesseduffield/lazydocker" ]
 ENV PATH=/bin
 COPY --from=docker-builder /go/src/github.com/docker/cli/build/docker /bin/docker
 COPY --from=builder /tmp/gobuild/lazydocker /bin/lazydocker

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,14 +34,16 @@ FROM scratch
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
-LABEL org.label-schema.schema-version="1.0.0-rc1" \
-    maintainer="jessedduffield@gmail.com" \
-    org.label-schema.build-date=$BUILD_DATE \
-    org.label-schema.vcs-ref=$VCS_REF \
-    org.label-schema.url="https://github.com/jesseduffield/lazydocker" \
-    org.label-schema.vcs-description="The lazier way to manage everything docker" \
-    org.label-schema.docker.cmd="docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazydocker" \
-    org.label-schema.version=${VERSION}
+LABEL \
+    org.opencontainers.image.authors="jessedduffield@gmail.com" \
+    org.opencontainers.image.created=$BUILD_DATE \
+    org.opencontainers.image.version=$VERSION \
+    org.opencontainers.image.revision=$VCS_REF \
+    org.opencontainers.image.url="https://github.com/jesseduffield/lazydocker" \
+    org.opencontainers.image.documentation="https://github.com/jesseduffield/lazydocker" \
+    org.opencontainers.image.source="https://github.com/jesseduffield/lazydocker" \
+    org.opencontainers.image.title="lazydocker" \
+    org.opencontainers.image.description="The lazier way to manage everything docker"
 ENTRYPOINT [ "/bin/lazydocker" ]
 ENV PATH=/bin
 COPY --from=docker-builder /go/src/github.com/docker/cli/build/docker /bin/docker

--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ go get github.com/jesseduffield/lazydocker
 
         ```sh
         docker build -t lazydocker https://github.com/jesseduffield/lazydocker.git
-        # or locally within the repository:
-        docker build -t lazydocker .
         ```
 
     - If you have a ARM 32 bit v6 architecture
@@ -93,7 +91,17 @@ go get github.com/jesseduffield/lazydocker
         https://github.com/jesseduffield/lazydocker.git
         ```
 
-    You can also add `--build-arg VCS_REF=$(git rev-parse HEAD)` so that the go build and the container contain the commit used.
+    - For development:
+
+        ```sh
+        git clone https://github.com/jesseduffield/lazydocker.git
+        cd lazydocker
+        docker build -t lazydocker \
+            --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+            --build-arg VCS_REF=`git rev-parse --short HEAD` \
+            --build-arg VERSION=`git describe --abbrev=0 --tag` \
+            .
+        ```
 
     </p></details>
 1. Run it

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ docker build -t lazyteam/lazydocker \
     .
 ```
 
+If you encounter a compatibility issue with Docker bundled binary, try rebuilding
+the image with the build argument `--build-arg DOCKER_VERSION="v$(docker -v | cut -d" " -f3 | rev | cut -c 2- | rev)"`
+so that the bundled docker binary matches your host docker binary version.
+
 ## Usage
 
 Call `lazydocker` in your terminal. I personally use this a lot so I've made an alias for it like so:

--- a/README.md
+++ b/README.md
@@ -95,10 +95,13 @@ go get github.com/jesseduffield/lazydocker
 1. Run the container
 
     ```sh
-    docker run -it -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/config:/.config/jesseduffield/lazydocker lazyteam/lazydocker
+    docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazyteam/lazydocker
     ```
 
     On Windows, replace `$(pwd)` by `%cd%`.
+
+    You can optionally bind mount the config directory with `-v $(pwd)/config:/.config/jesseduffield/lazydocker`,
+    although it is saved in a volume by default.
 
     You can also use this [docker-compose.yml](https://github.com/jesseduffield/lazydocker/blob/master/docker-compose.yml)
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,55 @@ required go version: 1.12
 go get github.com/jesseduffield/lazydocker
 ```
 
+### Docker
+
+1. <details><summary>Build it...</summary><p>
+
+    - If you have a x86_64 CPU architecture
+
+        ```sh
+        docker build -t lazydocker . https://github.com/jesseduffield/lazydocker.git
+        ```
+
+    - If you have a ARM 32 bit v6 architecture
+
+        ```sh
+        docker build -t lazydocker \
+        --build-arg BASE_IMAGE_BUILDER=arm32v6/golang \
+        --build-arg BASE_IMAGE=arm32v6/alpine \
+        --build-arg GOARCH=arm \
+        --build-arg GOARM=6 \
+        https://github.com/jesseduffield/lazydocker.git
+        ```
+
+    - If you have a ARM 32 bit v7 architecture
+
+        ```sh
+        docker build -t lazydocker \
+        --build-arg BASE_IMAGE_BUILDER=arm32v7/golang \
+        --build-arg BASE_IMAGE=arm32v7/alpine \
+        --build-arg GOARCH=arm \
+        --build-arg GOARM=7 \
+        https://github.com/jesseduffield/lazydocker.git
+        ```
+
+    - If you have a ARM 64 bit v8 architecture
+
+        ```sh
+        docker build -t lazydocker \
+        --build-arg BASE_IMAGE_BUILDER=arm64v8/golang \
+        --build-arg BASE_IMAGE=arm64v8/alpine \
+        --build-arg GOARCH=arm64 \
+        https://github.com/jesseduffield/lazydocker.git
+        ```
+
+    </p></details>
+1. Run it
+
+    ```sh
+    docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazydocker
+    ```
+
 ## Usage
 
 Call `lazydocker` in your terminal. I personally use this a lot so I've made an alias for it like so:

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ go get github.com/jesseduffield/lazydocker
         https://github.com/jesseduffield/lazydocker.git
         ```
 
+    You can also add `--build-arg VCS_REF=$(git rev-parse HEAD)` so that the go build and the container contain the commit used.
+
     </p></details>
 1. Run it
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ go get github.com/jesseduffield/lazydocker
     - If you have a x86_64 CPU architecture
 
         ```sh
-        docker build -t lazydocker . https://github.com/jesseduffield/lazydocker.git
+        docker build -t lazydocker https://github.com/jesseduffield/lazydocker.git
+        # or locally within the repository:
+        docker build -t lazydocker .
         ```
 
     - If you have a ARM 32 bit v6 architecture

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ go get github.com/jesseduffield/lazydocker
     docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazydocker
     ```
 
+1. Then enter `lazydocker`
+
 ## Usage
 
 Call `lazydocker` in your terminal. I personally use this a lot so I've made an alias for it like so:

--- a/README.md
+++ b/README.md
@@ -104,11 +104,19 @@ go get github.com/jesseduffield/lazydocker
         ```
 
     </p></details>
-1. Run it
+1. Create a directory *config* on your host:
 
     ```sh
-    docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazydocker
+    mkdir config
     ```
+
+1. Run the container
+
+    ```sh
+    docker run -it -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/config:/.config/jesseduffield/lazydocker lazydocker
+    ```
+
+    On Windows, replace `$(pwd)` by `%cd%`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -50,22 +50,16 @@ go get github.com/jesseduffield/lazydocker
 
 ### Docker
 
-[![Docker Pulls](https://img.shields.io/docker/pulls/jesseduffield/lazydocker.svg)](https://hub.docker.com/r/jesseduffield/lazydocker)
-[![Docker Stars](https://img.shields.io/docker/stars/jesseduffield/lazydocker.svg)](https://hub.docker.com/r/jesseduffield/lazydocker)
-[![Docker Automated](https://img.shields.io/docker/cloud/automated/jesseduffield/lazydocker.svg)](https://hub.docker.com/r/jesseduffield/lazydocker)
+[![Docker Pulls](https://img.shields.io/docker/pulls/lazyteam/lazydocker.svg)](https://hub.docker.com/r/lazyteam/lazydocker)
+[![Docker Stars](https://img.shields.io/docker/stars/lazyteam/lazydocker.svg)](https://hub.docker.com/r/lazyteam/lazydocker)
+[![Docker Automated](https://img.shields.io/docker/cloud/automated/lazyteam/lazydocker.svg)](https://hub.docker.com/r/lazyteam/lazydocker)
 
-1. <details><summary>Build it...</summary><p>
-
-    - If you have a x86_64 CPU architecture
-
-        ```sh
-        docker build -t lazydocker https://github.com/jesseduffield/lazydocker.git
-        ```
+1. <details><summary>Click if you have an ARM device</summary><p>
 
     - If you have a ARM 32 bit v6 architecture
 
         ```sh
-        docker build -t lazydocker \
+        docker build -t lazyteam/lazydocker \
         --build-arg BASE_IMAGE_BUILDER=arm32v6/golang \
         --build-arg GOARCH=arm \
         --build-arg GOARM=6 \
@@ -75,7 +69,7 @@ go get github.com/jesseduffield/lazydocker
     - If you have a ARM 32 bit v7 architecture
 
         ```sh
-        docker build -t lazydocker \
+        docker build -t lazyteam/lazydocker \
         --build-arg BASE_IMAGE_BUILDER=arm32v7/golang \
         --build-arg GOARCH=arm \
         --build-arg GOARM=7 \
@@ -85,22 +79,10 @@ go get github.com/jesseduffield/lazydocker
     - If you have a ARM 64 bit v8 architecture
 
         ```sh
-        docker build -t lazydocker \
+        docker build -t lazyteam/lazydocker \
         --build-arg BASE_IMAGE_BUILDER=arm64v8/golang \
         --build-arg GOARCH=arm64 \
         https://github.com/jesseduffield/lazydocker.git
-        ```
-
-    - For development:
-
-        ```sh
-        git clone https://github.com/jesseduffield/lazydocker.git
-        cd lazydocker
-        docker build -t lazydocker \
-            --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-            --build-arg VCS_REF=`git rev-parse --short HEAD` \
-            --build-arg VERSION=`git describe --abbrev=0 --tag` \
-            .
         ```
 
     </p></details>
@@ -113,10 +95,45 @@ go get github.com/jesseduffield/lazydocker
 1. Run the container
 
     ```sh
-    docker run -it -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/config:/.config/jesseduffield/lazydocker lazydocker
+    docker run -it -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/config:/.config/jesseduffield/lazydocker lazyteam/lazydocker
     ```
 
-    On Windows, replace `$(pwd)` by `%cd%`
+    On Windows, replace `$(pwd)` by `%cd%`.
+
+    <details><summary>You can also use docker-compose</summary><p>
+
+    ```yml
+    version: '3'
+    services:
+      lazydocker:
+        build:
+          context: https://github.com/jesseduffield/lazydocker.git
+          args:
+            BASE_IMAGE_BUILDER: golang
+            GOARCH: amd64
+            GOARM:
+        image: jesseduffield/lazydocker
+        container_name: lazydocker
+        stdin_open: true
+        tty: true
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+          - ./config:/.config/jesseduffield/lazydocker
+    ```
+
+    </p></details>
+
+For development, you can build the image using:
+
+```sh
+git clone https://github.com/jesseduffield/lazydocker.git
+cd lazydocker
+docker build -t lazyteam/lazydocker \
+    --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+    --build-arg VCS_REF=`git rev-parse --short HEAD` \
+    --build-arg VERSION=`git describe --abbrev=0 --tag` \
+    .
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,6 @@ go get github.com/jesseduffield/lazydocker
     docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazydocker
     ```
 
-1. Then enter `lazydocker`
-
 ## Usage
 
 Call `lazydocker` in your terminal. I personally use this a lot so I've made an alias for it like so:

--- a/README.md
+++ b/README.md
@@ -86,24 +86,25 @@ go get github.com/jesseduffield/lazydocker
         ```
 
     </p></details>
-1. Create a directory *config* on your host:
-
-    ```sh
-    mkdir config
-    ```
 
 1. Run the container
 
     ```sh
-    docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazyteam/lazydocker
+    docker run -it -v \
+    /var/run/docker.sock:/var/run/docker.sock \
+    -v /yourpath:/.config/jesseduffield/lazydocker \
+    lazyteam/lazydocker
     ```
 
-    On Windows, replace `$(pwd)` by `%cd%`.
+    - Don't forget to change `/yourpath` to an actual path you created to store lazydocker's config
+    - You can also use this [docker-compose.yml](https://github.com/jesseduffield/lazydocker/blob/master/docker-compose.yml)
+    - You might want to create an alias, for example:
 
-    You can optionally bind mount the config directory with `-v $(pwd)/config:/.config/jesseduffield/lazydocker`,
-    although it is saved in a volume by default.
+        ```sh
+        echo "alias ld='docker run -it -v /var/run/docker.sock:/var/run/docker.sock -v /yourpath/config:/.config/jesseduffield/lazydocker lazyteam/lazydocker'" >> ~/.zshrc
+        ```
 
-    You can also use this [docker-compose.yml](https://github.com/jesseduffield/lazydocker/blob/master/docker-compose.yml)
+
 
 For development, you can build the image using:
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ go get github.com/jesseduffield/lazydocker
 
 ### Docker
 
+[![Docker Pulls](https://img.shields.io/docker/pulls/jesseduffield/lazydocker.svg)](https://hub.docker.com/r/jesseduffield/lazydocker)
+[![Docker Stars](https://img.shields.io/docker/stars/jesseduffield/lazydocker.svg)](https://hub.docker.com/r/jesseduffield/lazydocker)
+[![Docker Automated](https://img.shields.io/docker/cloud/automated/jesseduffield/lazydocker.svg)](https://hub.docker.com/r/jesseduffield/lazydocker)
+
 1. <details><summary>Build it...</summary><p>
 
     - If you have a x86_64 CPU architecture

--- a/README.md
+++ b/README.md
@@ -100,28 +100,7 @@ go get github.com/jesseduffield/lazydocker
 
     On Windows, replace `$(pwd)` by `%cd%`.
 
-    <details><summary>You can also use docker-compose</summary><p>
-
-    ```yml
-    version: '3'
-    services:
-      lazydocker:
-        build:
-          context: https://github.com/jesseduffield/lazydocker.git
-          args:
-            BASE_IMAGE_BUILDER: golang
-            GOARCH: amd64
-            GOARM:
-        image: jesseduffield/lazydocker
-        container_name: lazydocker
-        stdin_open: true
-        tty: true
-        volumes:
-          - /var/run/docker.sock:/var/run/docker.sock
-          - ./config:/.config/jesseduffield/lazydocker
-    ```
-
-    </p></details>
+    You can also use this [docker-compose.yml](https://github.com/jesseduffield/lazydocker/blob/master/docker-compose.yml)
 
 For development, you can build the image using:
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ go get github.com/jesseduffield/lazydocker
         ```sh
         docker build -t lazydocker \
         --build-arg BASE_IMAGE_BUILDER=arm32v6/golang \
-        --build-arg BASE_IMAGE=arm32v6/alpine \
         --build-arg GOARCH=arm \
         --build-arg GOARM=6 \
         https://github.com/jesseduffield/lazydocker.git
@@ -80,7 +79,6 @@ go get github.com/jesseduffield/lazydocker
         ```sh
         docker build -t lazydocker \
         --build-arg BASE_IMAGE_BUILDER=arm32v7/golang \
-        --build-arg BASE_IMAGE=arm32v7/alpine \
         --build-arg GOARCH=arm \
         --build-arg GOARM=7 \
         https://github.com/jesseduffield/lazydocker.git
@@ -91,7 +89,6 @@ go get github.com/jesseduffield/lazydocker
         ```sh
         docker build -t lazydocker \
         --build-arg BASE_IMAGE_BUILDER=arm64v8/golang \
-        --build-arg BASE_IMAGE=arm64v8/alpine \
         --build-arg GOARCH=arm64 \
         https://github.com/jesseduffield/lazydocker.git
         ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  lazydocker:
+    build:
+      context: https://github.com/jesseduffield/lazydocker.git
+      args:
+        BASE_IMAGE_BUILDER: golang
+        GOARCH: amd64
+        GOARM:
+    image: jesseduffield/lazydocker
+    container_name: lazydocker
+    stdin_open: true
+    tty: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./config:/.config/jesseduffield/lazydocker

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+             --build-arg VCS_REF=`git rev-parse --short HEAD` \
+             --build-arg VERSION=`git describe --abbrev=0 --tag` \
+             -t $IMAGE_NAME .

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -2,7 +2,11 @@ package app
 
 import (
 	"io"
+	"os"
 	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/jesseduffield/lazydocker/pkg/commands"
 	"github.com/jesseduffield/lazydocker/pkg/config"
@@ -51,8 +55,18 @@ func NewApp(config *config.AppConfig) (*App, error) {
 }
 
 func (app *App) Run() error {
+	// before we do anything, we need to check that we have some window space available
+	for {
+		width, _, err := terminal.GetSize(int(os.Stdin.Fd()))
+		if err != nil {
+			return err
+		}
+		if width == 0 {
+			time.Sleep(time.Millisecond * 50)
+		}
+		break
+	}
 	err := app.Gui.RunWithSubprocesses()
-
 	return err
 }
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -56,17 +56,16 @@ func NewApp(config *config.AppConfig) (*App, error) {
 
 func (app *App) Run() error {
 	// before we do anything, we need to check that we have some window space available
-	for {
-		width, _, err := terminal.GetSize(int(os.Stdin.Fd()))
+	var err error
+	width := 0
+	for width == 0 {
+		width, _, err = terminal.GetSize(int(os.Stdin.Fd()))
 		if err != nil {
 			return err
 		}
-		if width == 0 {
-			time.Sleep(time.Millisecond * 50)
-		}
-		break
+		time.Sleep(time.Millisecond * 50)
 	}
-	err := app.Gui.RunWithSubprocesses()
+	err = app.Gui.RunWithSubprocesses()
 	return err
 }
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -75,7 +75,7 @@ func waitForTerminalSpace() error {
 	if width > 0 && height > 0 {
 		return nil
 	}
-	winch := make(chan os.Signal)
+	winch := make(chan os.Signal, 1)
 	signal.Notify(winch, syscall.SIGWINCH)
 	select {
 	case <-winch:

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,15 +1,8 @@
 package app
 
 import (
-	"fmt"
 	"io"
-	"os"
-	"os/signal"
 	"strings"
-	"syscall"
-	"time"
-
-	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/jesseduffield/lazydocker/pkg/commands"
 	"github.com/jesseduffield/lazydocker/pkg/config"
@@ -58,31 +51,8 @@ func NewApp(config *config.AppConfig) (*App, error) {
 }
 
 func (app *App) Run() error {
-	err := waitForTerminalSpace()
-	if err != nil {
-		return err
-	}
-	err = app.Gui.RunWithSubprocesses()
+	err := app.Gui.RunWithSubprocesses()
 	return err
-}
-
-func waitForTerminalSpace() error {
-	// before we do anything, we need to check that we have some window space available
-	width, height, err := terminal.GetSize(int(os.Stdin.Fd()))
-	if err != nil {
-		return err
-	}
-	if width > 0 && height > 0 {
-		return nil
-	}
-	winch := make(chan os.Signal, 1)
-	signal.Notify(winch, syscall.SIGWINCH)
-	select {
-	case <-winch:
-		return nil
-	case <-time.After(time.Second):
-		return fmt.Errorf("there is no available terminal space")
-	}
 }
 
 // Close closes any resources


### PR DESCRIPTION
- Added .dockerignore to speed up build context and avoid rebuilding when unecessary
- Specified Alpine and Go versions as build arguments
- Specified Go target CPU architecture as build arguments to be able to build for ARM devices
- Specified base images as build arguments to be able to build for ARM devices
- Trimmed down size of final image using `-a -installsuffix cgo -ldflags="-s -w"` go build flags and by copying the statically built binary only to the final image
- Added clear build and run instructions for the Docker container