### PR TITLE
Updated the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-
+lazydocker*
 TODO.md
 Lazydocker.code-workspace
+.vscode


### PR DESCRIPTION
There seems to be a few missing items in the `.gitignore`  
- `.vscode` The vscode workspace spesific settings
- `lazydocker*` The `go build` output