### PR TITLE
Add automated install-update steps for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,19 @@ brew install lazydocker
 
 ### Binary Release (Linux/OSX)
 
-You can download a binary release [here](https://github.com/jesseduffield/lazydocker/releases).
+You can manually download a binary release from [the release page](https://github.com/jesseduffield/lazydocker/releases).
+
+Automated install/update:
+
+```sh
+GITHUB_LATEST_VERSION=$(curl -L -s -H 'Accept: application/json' https://github.com/jesseduffield/lazydocker/releases/latest | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+GITHUB_FILE="lazydocker_${GITHUB_LATEST_VERSION//v/}_$(uname -s)_$(uname -m).tar.gz"
+GITHUB_URL="https://github.com/jesseduffield/lazydocker/releases/download/${GITHUB_LATEST_VERSION}/${GITHUB_FILE}"
+wget -O lazydocker.tar.gz $GITHUB_URL
+tar xzvf lazydocker.tar.gz lazydocker
+sudo mv -f lazydocker /usr/local/bin/
+rm lazydocker.tar.gz
+```
 
 ### Go
 

--- a/README.md
+++ b/README.md
@@ -40,16 +40,10 @@ brew install lazydocker
 
 You can manually download a binary release from [the release page](https://github.com/jesseduffield/lazydocker/releases).
 
-Automated install/update:
+Automated install/update, don't forget to always verify what you're piping into bash:
 
 ```sh
-GITHUB_LATEST_VERSION=$(curl -L -s -H 'Accept: application/json' https://github.com/jesseduffield/lazydocker/releases/latest | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
-GITHUB_FILE="lazydocker_${GITHUB_LATEST_VERSION//v/}_$(uname -s)_$(uname -m).tar.gz"
-GITHUB_URL="https://github.com/jesseduffield/lazydocker/releases/download/${GITHUB_LATEST_VERSION}/${GITHUB_FILE}"
-wget -O lazydocker.tar.gz $GITHUB_URL
-tar xzvf lazydocker.tar.gz lazydocker
-sudo mv -f lazydocker /usr/local/bin/
-rm lazydocker.tar.gz
+curl https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/install_update_linux.sh | bash
 ```
 
 ### Go

--- a/scripts/install_update_linux.sh
+++ b/scripts/install_update_linux.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+GITHUB_LATEST_VERSION=$(curl -L -s -H 'Accept: application/json' https://github.com/jesseduffield/lazydocker/releases/latest | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+GITHUB_FILE="lazydocker_${GITHUB_LATEST_VERSION//v/}_$(uname -s)_$(uname -m).tar.gz"
+GITHUB_URL="https://github.com/jesseduffield/lazydocker/releases/download/${GITHUB_LATEST_VERSION}/${GITHUB_FILE}"
+
+wget -O lazydocker.tar.gz $GITHUB_URL
+tar xzvf lazydocker.tar.gz lazydocker
+sudo mv -f lazydocker /usr/local/bin/
+rm lazydocker.tar.gz


### PR DESCRIPTION
Hi, I've added a small code snippet to be able to download and install/update the binary file without manual steps. Tested on Ubuntu and Manjaro Linux distros. Also improved the clickability of the release link.