### PR TITLE
Updates README.md with a better alias suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ go get github.com/jesseduffield/lazydocker
 Call `lazydocker` in your terminal. I personally use this a lot so I've made an alias for it like so:
 
 ```
-echo "alias ld='lazydocker'" >> ~/.zshrc
+echo "alias lzd='lazydocker'" >> ~/.zshrc
 ```
 
 (you can substitute .zshrc for whatever rc file you're using)


### PR DESCRIPTION
`ld` is actually a pretty important command-line tool, so overwriting it with the suggested alias is not preferable. `lzd` is just my idea, but really this is just to notify you.

More on `ld`: https://linux.die.net/man/1/ld