### PR TITLE
Launch OpenFile command in sub process

### DIFF
--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -128,15 +128,14 @@ func sanitisedCommandOutput(output []byte, err error) (string, error) {
 }
 
 // OpenFile opens a file with the given
-func (c *OSCommand) OpenFile(filename string) error {
+func (c *OSCommand) OpenFile(filename string) (*exec.Cmd, error) {
 	commandTemplate := c.Config.UserConfig.OS.OpenCommand
 	templateValues := map[string]string{
 		"filename": c.Quote(filename),
 	}
 
-	command := utils.ResolvePlaceholderString(commandTemplate, templateValues)
-	err := c.RunCommand(command)
-	return err
+	command := c.ExecutableFromString(utils.ResolvePlaceholderString(commandTemplate, templateValues))
+	return command, nil
 }
 
 // OpenLink opens a file with the given

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -345,10 +345,8 @@ func (gui *Gui) editFile(filename string) error {
 }
 
 func (gui *Gui) openFile(filename string) error {
-	if err := gui.OSCommand.OpenFile(filename); err != nil {
-		return gui.createErrorPanel(gui.g, err.Error())
-	}
-	return nil
+	_, err := gui.runSyncOrAsyncCommand(gui.OSCommand.OpenFile(filename))
+	return err
 }
 
 // runSyncOrAsyncCommand takes the output of a command that may have returned


### PR DESCRIPTION
Fixes #71 

My `xdg-open` opens vim.  With this change and setting my .config file to have:

```
oS:
  openCommand: xdg-open {{filename}}
```
I can now open the config file from lazydocker's TUI.


Can someone on Windows/OSX try this out?  Is this change a good idea?  I'm unsure how this will affect user's whose `xdg-open` doesn't open a terminal program or another operating system's use case.  Is removing the redirect to >dev/null in the default open command appropriate?