### PR TITLE
Added rounding to timing (fixes #94)

### DIFF
--- a/pkg/commands/container_stats.go
+++ b/pkg/commands/container_stats.go
@@ -256,7 +256,7 @@ func (c *Container) PlotGraph(spec config.GraphConfig, width int) (string, error
 		asciigraph.Width(width),
 		asciigraph.Min(min),
 		asciigraph.Max(max),
-		asciigraph.Caption(fmt.Sprintf("%s: %0.2f (%v)", spec.Caption, data[len(data)-1], time.Since(c.StatHistory[0].RecordedAt))),
+		asciigraph.Caption(fmt.Sprintf("%s: %0.2f (%v)", spec.Caption, data[len(data)-1], time.Since(c.StatHistory[0].RecordedAt).Round(time.Second))),
 	), nil
 }
 


### PR DESCRIPTION
This fixes #94  
Now it shows: `1h27m13s` in staid of `1h27m13.246503645s`  