### PR TITLE
Add a limit to the c.StatsHistory

### DIFF
--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -179,12 +179,7 @@ func (c *DockerCommand) createClientStatMonitor(container *Container) {
 		}
 
 		c.ContainerMutex.Lock()
-		toSlice := len(container.StatHistory) - 50
-		if toSlice < 0 {
-			toSlice = 0
-		}
-		container.StatHistory = append(container.StatHistory[toSlice:], recordedStats)
-
+		container.StatHistory = append(container.StatHistory, recordedStats)
 		container.EraseOldHistory()
 		c.ContainerMutex.Unlock()
 	}

--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -179,7 +179,12 @@ func (c *DockerCommand) createClientStatMonitor(container *Container) {
 		}
 
 		c.ContainerMutex.Lock()
-		container.StatHistory = append(container.StatHistory, recordedStats)
+		toSlice := len(container.StatHistory) - 50
+		if toSlice < 0 {
+			toSlice = 0
+		}
+		container.StatHistory = append(container.StatHistory[toSlice:], recordedStats)
+
 		container.EraseOldHistory()
 		c.ContainerMutex.Unlock()
 	}

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -289,6 +289,11 @@ type CustomCommand struct {
 // the boolean zero value and this will be ignored when parsing the user's
 // config
 func GetDefaultConfig() UserConfig {
+	duration, err := time.ParseDuration("3m")
+	if err != nil {
+		panic(err)
+	}
+
 	return UserConfig{
 		Gui: GuiConfig{
 			ScrollHeight:      2,
@@ -336,6 +341,7 @@ func GetDefaultConfig() UserConfig {
 			Method: "never",
 		},
 		Stats: StatsConfig{
+			MaxDuration: duration,
 			Graphs: []GraphConfig{
 				{
 					Caption:  "CPU (%)",


### PR DESCRIPTION
While trying to fix #76 i found that the stats didn't have a limit.  
This might be why lazydocker seems to crash over a long time but from the time in #76 screenshots (17498s what is equal to the amount of array items) this seems wired because a slice can have more than that amount of items  

Beside that i don't think that it's a good idea looping every second over an array with 10000+ items.