### PR TITLE
Docker Swarm stack support

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ var (
 
 	configFlag    = false
 	debuggingFlag = false
+	dockerSwarm   = false
 	composeFiles  []string
 )
 
@@ -44,6 +45,7 @@ func main() {
 	flaggy.Bool(&configFlag, "c", "config", "Print the current default config")
 	flaggy.Bool(&debuggingFlag, "d", "debug", "a boolean")
 	flaggy.StringSlice(&composeFiles, "f", "file", "Specify alternate compose files")
+	flaggy.Bool(&dockerSwarm, "s", "swarm", "ue DOcker Swarm mode")
 	flaggy.SetVersion(info)
 
 	flaggy.Parse()
@@ -64,7 +66,7 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	appConfig, err := config.NewAppConfig("lazydocker", version, commit, date, buildSource, debuggingFlag, composeFiles, projectDir)
+	appConfig, err := config.NewAppConfig("lazydocker", version, commit, date, buildSource, debuggingFlag, dockerSwarm, composeFiles, projectDir)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"fmt"
 	"io"
 	"strings"
 
@@ -46,7 +45,6 @@ func NewApp(config *config.AppConfig) (*App, error) {
 	}
 
 	// TODO: detect if swarm mode is on..
-	fmt.Printf("SWARM: %s\n", app.Config.DockerSwarm)
 
 	app.Gui, err = gui.NewGui(app.Log, app.DockerCommand, app.OSCommand, app.Tr, app.Config, app.ErrorChan)
 	if err != nil {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
@@ -35,7 +36,7 @@ func NewApp(config *config.AppConfig) (*App, error) {
 	var err error
 	app.Log = log.NewLogger(config, "23432119147a4367abf7c0de2aa99a2d")
 	app.Tr = i18n.NewTranslationSet(app.Log)
-	app.OSCommand = commands.NewOSCommand(app.Log, config)
+	app.OSCommand = commands.NewOSCommand(app.Log, app.Config)
 
 	// here is the place to make use of the docker-compose.yml file in the current directory
 
@@ -43,7 +44,11 @@ func NewApp(config *config.AppConfig) (*App, error) {
 	if err != nil {
 		return app, err
 	}
-	app.Gui, err = gui.NewGui(app.Log, app.DockerCommand, app.OSCommand, app.Tr, config, app.ErrorChan)
+
+	// TODO: detect if swarm mode is on..
+	fmt.Printf("SWARM: %s\n", app.Config.DockerSwarm)
+
+	app.Gui, err = gui.NewGui(app.Log, app.DockerCommand, app.OSCommand, app.Tr, app.Config, app.ErrorChan)
 	if err != nil {
 		return app, err
 	}

--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -92,7 +92,7 @@ func NewDockerCommand(log *logrus.Entry, osCommand *OSCommand, tr *i18n.Translat
 
 	err = osCommand.RunCommand(command)
 	if err != nil {
-		//dockerCommand.InDockerComposeProject = false
+		dockerCommand.InDockerComposeProject = false
 		log.Warn(err.Error())
 	}
 

--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -219,11 +219,11 @@ func (c *DockerCommand) RefreshContainersAndServices() error {
 
 	// sort services first by whether they have a linked container, and second by alphabetical order
 	sort.Slice(services, func(i, j int) bool {
-		if services[i].Container != nil && services[j].Container == nil {
+		if len(services[i].Containers) > 0 && len(services[j].Containers) == 0 {
 			return true
 		}
 
-		if services[i].Container == nil && services[j].Container != nil {
+		if len(services[i].Containers) == 0 && len(services[j].Containers) > 0 {
 			return false
 		}
 
@@ -241,7 +241,7 @@ func (c *DockerCommand) assignContainersToServices(containers []*Container, serv
 	for _, service := range services {
 		for _, container := range containers {
 			if /*!container.OneOff &&*/ container.ServiceName == service.Name {
-				service.Container = append(service.Container, container)
+				service.Containers = append(service.Containers, container)
 				continue
 			}
 		}

--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -238,20 +238,19 @@ func (c *DockerCommand) RefreshContainersAndServices() error {
 }
 
 func (c *DockerCommand) assignContainersToServices(containers []*Container, services []*Service) {
-L:
 	for _, service := range services {
 		for _, container := range containers {
 			if !container.OneOff && container.ServiceName == service.Name {
-				service.Container = container
-				continue L
+				service.Container = append(service.Container, container)
+				continue
 			}
 			if container.Container.Labels["com.docker.swarm.service.name"] == service.Name {
 				//Swarm service
-				service.Container = container
-				continue L
+				service.Container = append(service.Container, container)
+				container.ServiceName = service.Name
+				continue
 			}
 		}
-		service.Container = nil
 	}
 }
 

--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -240,14 +240,8 @@ func (c *DockerCommand) RefreshContainersAndServices() error {
 func (c *DockerCommand) assignContainersToServices(containers []*Container, services []*Service) {
 	for _, service := range services {
 		for _, container := range containers {
-			if !container.OneOff && container.ServiceName == service.Name {
+			if /*!container.OneOff &&*/ container.ServiceName == service.Name {
 				service.Container = append(service.Container, container)
-				continue
-			}
-			if container.Container.Labels["com.docker.swarm.service.name"] == service.Name {
-				//Swarm service
-				service.Container = append(service.Container, container)
-				container.ServiceName = service.Name
 				continue
 			}
 		}
@@ -330,7 +324,15 @@ func (c *DockerCommand) GetContainers() ([]*Container, error) {
 			newContainer.Name = strings.TrimLeft(container.Names[0], "/")
 		}
 		newContainer.ServiceName = container.Labels["com.docker.compose.service"]
+		if container.Labels["com.docker.swarm.service.name"] != "" {
+			newContainer.ServiceName = container.Labels["com.docker.swarm.service.name"]
+		}
+
 		newContainer.ProjectName = container.Labels["com.docker.compose.project"]
+		if container.Labels["com.docker.stack.namespace"] != "" {
+			newContainer.ProjectName = container.Labels["com.docker.stack.namespace"]
+		}
+
 		newContainer.ContainerNumber = container.Labels["com.docker.compose.container"]
 		newContainer.OneOff = container.Labels["com.docker.compose.oneoff"] == "True"
 

--- a/pkg/commands/service.go
+++ b/pkg/commands/service.go
@@ -17,24 +17,24 @@ type Service struct {
 	ID            string
 	OSCommand     *OSCommand
 	Log           *logrus.Entry
-	Container     []*Container
+	Containers    []*Container
 	DockerCommand LimitedDockerCommand
 }
 
 // GetDisplayStrings returns the dispaly string of Container
 func (s *Service) GetDisplayStrings(isFocused bool) []string {
 
-	if len(s.Container) == 0 {
+	if len(s.Containers) == 0 {
 		return []string{utils.ColoredString("none", color.FgBlue), s.Name, ""}
 	}
 
-	cont := s.Container[0]
+	cont := s.Containers[0]
 	return []string{cont.GetDisplayStatus(), s.Name, cont.GetDisplayCPUPerc()}
 }
 
 // Remove removes the service's containers
 func (s *Service) Remove(options types.ContainerRemoveOptions) error {
-	return s.Container[0].Remove(options)
+	return s.Containers[0].Remove(options)
 }
 
 // Stop stops the service's containers
@@ -59,12 +59,12 @@ func (s *Service) Restart() error {
 
 // Attach attaches to the service
 func (s *Service) Attach() (*exec.Cmd, error) {
-	return s.Container[0].Attach()
+	return s.Containers[0].Attach()
 }
 
 // Top returns process information
 func (s *Service) Top() (container.ContainerTopOKBody, error) {
-	return s.Container[0].Top()
+	return s.Containers[0].Top()
 }
 
 // ViewLogs attaches to a subprocess viewing the service's logs

--- a/pkg/commands/service.go
+++ b/pkg/commands/service.go
@@ -1,8 +1,9 @@
 package commands
 
 import (
-	"github.com/docker/docker/api/types/container"
 	"os/exec"
+
+	"github.com/docker/docker/api/types/container"
 
 	"github.com/docker/docker/api/types"
 	"github.com/fatih/color"
@@ -16,24 +17,24 @@ type Service struct {
 	ID            string
 	OSCommand     *OSCommand
 	Log           *logrus.Entry
-	Container     *Container
+	Container     []*Container
 	DockerCommand LimitedDockerCommand
 }
 
 // GetDisplayStrings returns the dispaly string of Container
 func (s *Service) GetDisplayStrings(isFocused bool) []string {
 
-	if s.Container == nil {
+	if len(s.Container) == 0 {
 		return []string{utils.ColoredString("none", color.FgBlue), s.Name, ""}
 	}
 
-	cont := s.Container
+	cont := s.Container[0]
 	return []string{cont.GetDisplayStatus(), s.Name, cont.GetDisplayCPUPerc()}
 }
 
 // Remove removes the service's containers
 func (s *Service) Remove(options types.ContainerRemoveOptions) error {
-	return s.Container.Remove(options)
+	return s.Container[0].Remove(options)
 }
 
 // Stop stops the service's containers
@@ -58,12 +59,12 @@ func (s *Service) Restart() error {
 
 // Attach attaches to the service
 func (s *Service) Attach() (*exec.Cmd, error) {
-	return s.Container.Attach()
+	return s.Container[0].Attach()
 }
 
 // Top returns process information
 func (s *Service) Top() (container.ContainerTopOKBody, error) {
-	return s.Container.Top()
+	return s.Container[0].Top()
 }
 
 // ViewLogs attaches to a subprocess viewing the service's logs

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -429,6 +429,7 @@ func GetDefaultConfig() UserConfig {
 // AppConfig contains the base configuration fields required for lazydocker.
 type AppConfig struct {
 	Debug       bool   `long:"debug" env:"DEBUG" default:"false"`
+	DockerSwarm bool   `long:"debug" default:"false`
 	Version     string `long:"version" env:"VERSION" default:"unversioned"`
 	Commit      string `long:"commit" env:"COMMIT"`
 	BuildDate   string `long:"build-date" env:"BUILD_DATE"`
@@ -440,7 +441,7 @@ type AppConfig struct {
 }
 
 // NewAppConfig makes a new app config
-func NewAppConfig(name, version, commit, date string, buildSource string, debuggingFlag bool, composeFiles []string, projectDir string) (*AppConfig, error) {
+func NewAppConfig(name, version, commit, date string, buildSource string, debuggingFlag, dockerSwarm bool, composeFiles []string, projectDir string) (*AppConfig, error) {
 	configDir, err := findOrCreateConfigDir(name)
 	if err != nil {
 		return nil, err
@@ -462,6 +463,7 @@ func NewAppConfig(name, version, commit, date string, buildSource string, debugg
 		Commit:      commit,
 		BuildDate:   date,
 		Debug:       debuggingFlag || os.Getenv("DEBUG") == "TRUE",
+		DockerSwarm: dockerSwarm,
 		BuildSource: buildSource,
 		UserConfig:  userConfig,
 		ConfigDir:   configDir,

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -175,6 +175,11 @@ type CommandTemplatesConfig struct {
 	// file(s)
 	DockerComposeConfig string `yaml:"dockerComposeConfig,omitempty"`
 
+	// Print the service config hash, one per line.
+	// Set "service1,service2" for a list of specified services
+	// or use the wildcard symbol to display all services
+	DockerComposeConfigHash string `yaml:"dockerComposeConfigHash,omitempty"`
+
 	// CheckDockerComposeConfig is what we use to check whether we are in a
 	// docker-compose context. If the command returns an error then we clearly
 	// aren't in a docker-compose config and we then just hide the services panel
@@ -335,6 +340,7 @@ func GetDefaultConfig() UserConfig {
 			AllLogs:                  "{{ .DockerCompose }} logs --tail=300 --follow",
 			ViewAllLogs:              "{{ .DockerCompose }} logs",
 			DockerComposeConfig:      "{{ .DockerCompose }} config",
+			DockerComposeConfigHash:  "{{ .DockerCompose }} config --hash=*",
 			CheckDockerComposeConfig: "{{ .DockerCompose }} config --quiet",
 			ContainerLogs:            "docker logs --timestamps --follow --since=60m {{ .Container.ID }}",
 			ViewContainerLogs:        "docker logs --timestamps --follow --since=60m {{ .Container.ID }}",

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -148,11 +148,7 @@ func NewGui(log *logrus.Entry, dockerCommand *commands.DockerCommand, oSCommand 
 	}
 
 	cyclableViews := []string{"project", "containers", "images"}
-	if config.DockerSwarm {
-		dockerCommand.InDockerComposeProject = true
-	}
-	if dockerCommand.InDockerComposeProject {
-		// Frustratingly, this is not actually the driver for what views are shown - the InDOckerComposeProject var is used inside the gui code
+	if dockerCommand.InDockerComposeProject || config.DockerSwarm {
 		cyclableViews = []string{"project", "services", "containers", "images", "volumes"}
 	}
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -147,8 +147,12 @@ func NewGui(log *logrus.Entry, dockerCommand *commands.DockerCommand, oSCommand 
 		SessionIndex: 0,
 	}
 
-	cyclableViews := []string{"project", "containers", "images", "volumes"}
+	cyclableViews := []string{"project", "containers", "images"}
+	if config.DockerSwarm {
+		dockerCommand.InDockerComposeProject = true
+	}
 	if dockerCommand.InDockerComposeProject {
+		// Frustratingly, this is not actually the driver for what views are shown - the InDOckerComposeProject var is used inside the gui code
 		cyclableViews = []string{"project", "services", "containers", "images", "volumes"}
 	}
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -147,7 +147,7 @@ func NewGui(log *logrus.Entry, dockerCommand *commands.DockerCommand, oSCommand 
 		SessionIndex: 0,
 	}
 
-	cyclableViews := []string{"project", "containers", "images"}
+	cyclableViews := []string{"project", "containers", "images", "volumes"}
 	if dockerCommand.InDockerComposeProject || config.DockerSwarm {
 		cyclableViews = []string{"project", "services", "containers", "images", "volumes"}
 	}

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -192,11 +192,10 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		v.FgColor = gocui.ColorDefault
 	}
 
-	var servicesView *gocui.View
 	aboveContainersView := "project"
 	if showServicesPanel {
 		aboveContainersView = "services"
-		servicesView, err = g.SetViewBeneath("services", "project", vHeights["services"])
+		servicesView, err := g.SetViewBeneath("services", "project", vHeights["services"])
 		if err != nil {
 			if err.Error() != "unknown view" {
 				return err

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -195,50 +195,16 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 	aboveContainersView := "project"
 	if showServicesPanel {
 		aboveContainersView = "services"
-		servicesView, err := g.SetViewBeneath("services", "project", vHeights["services"])
-		if err != nil {
-			if err.Error() != "unknown view" {
-				return err
-			}
-			servicesView.Highlight = true
-			servicesView.Title = gui.Tr.ServicesTitle
-			servicesView.FgColor = gocui.ColorDefault
-		}
+		addView(g, "services", "project", gui.Tr.ServicesTitle, vHeights["services"])
 	}
 
-	containersView, err := g.SetViewBeneath("containers", aboveContainersView, vHeights["containers"])
-	if err != nil {
-		if err.Error() != "unknown view" {
-			return err
-		}
-		containersView.Highlight = true
-		if gui.Config.UserConfig.Gui.ShowAllContainers || !showServicesPanel {
-			containersView.Title = gui.Tr.ContainersTitle
-		} else {
-			containersView.Title = gui.Tr.StandaloneContainersTitle
-		}
-		containersView.FgColor = gocui.ColorDefault
+	containerTitle := gui.Tr.StandaloneContainersTitle
+	if gui.Config.UserConfig.Gui.ShowAllContainers || !showServicesPanel {
+		containerTitle = gui.Tr.ContainersTitle
 	}
-
-	imagesView, err := g.SetViewBeneath("images", "containers", vHeights["images"])
-	if err != nil {
-		if err.Error() != "unknown view" {
-			return err
-		}
-		imagesView.Highlight = true
-		imagesView.Title = gui.Tr.ImagesTitle
-		imagesView.FgColor = gocui.ColorDefault
-	}
-
-	volumesView, err := g.SetViewBeneath("volumes", "images", vHeights["volumes"])
-	if err != nil {
-		if err.Error() != "unknown view" {
-			return err
-		}
-		volumesView.Highlight = true
-		volumesView.Title = gui.Tr.VolumesTitle
-		volumesView.FgColor = gocui.ColorDefault
-	}
+	addView(g, "containers", aboveContainersView, containerTitle, vHeights["containers"])
+	addView(g, "images", "containers", gui.Tr.ImagesTitle, vHeights["images"])
+	addView(g, "volumes", "images", gui.Tr.VolumesTitle, vHeights["volumes"])
 
 	if v, err := g.SetView("options", appStatusOptionsBoundary-1, height-2, optionsVersionBoundary-1, height, 0); err != nil {
 		if err.Error() != "unknown view" {
@@ -299,6 +265,19 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 	// this will let you see these branches as prettified json
 	// gui.Log.Info(utils.AsJson(gui.State.Branches[0:4]))
 	return gui.resizeCurrentPopupPanel(g)
+}
+
+func addView(g *gocui.Gui, name, after, title string, height int) error {
+	imagesView, err := g.SetViewBeneath(name, after, height)
+	if err != nil {
+		if err.Error() != "unknown view" {
+			return err
+		}
+		imagesView.Highlight = true
+		imagesView.Title = title
+		imagesView.FgColor = gocui.ColorDefault
+	}
+	return nil
 }
 
 type listViewState struct {

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -184,27 +184,34 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		v.IgnoreCarriageReturns = true
 	}
 
+	titles := map[string]string{
+		"project":    gui.Tr.ProjectTitle,
+		"services":   gui.Tr.ServicesTitle,
+		"containers": gui.Tr.StandaloneContainersTitle,
+		"images":     gui.Tr.ImagesTitle,
+		"volumes":    gui.Tr.VolumesTitle,
+	}
+	if gui.Config.UserConfig.Gui.ShowAllContainers || !showServicesPanel {
+		titles["containers"] = gui.Tr.ContainersTitle
+	}
+
 	if v, err := g.SetView("project", 0, 0, leftSideWidth, vHeights["project"]-1, gocui.BOTTOM|gocui.RIGHT); err != nil {
 		if err.Error() != "unknown view" {
 			return err
 		}
-		v.Title = gui.Tr.ProjectTitle
+		v.Title = titles["project"]
 		v.FgColor = gocui.ColorDefault
 	}
 
 	aboveContainersView := "project"
 	if showServicesPanel {
 		aboveContainersView = "services"
-		addView(g, "services", "project", gui.Tr.ServicesTitle, vHeights["services"])
+		addView(g, "services", "project", titles["services"], vHeights["services"])
 	}
 
-	containerTitle := gui.Tr.StandaloneContainersTitle
-	if gui.Config.UserConfig.Gui.ShowAllContainers || !showServicesPanel {
-		containerTitle = gui.Tr.ContainersTitle
-	}
-	addView(g, "containers", aboveContainersView, containerTitle, vHeights["containers"])
-	addView(g, "images", "containers", gui.Tr.ImagesTitle, vHeights["images"])
-	addView(g, "volumes", "images", gui.Tr.VolumesTitle, vHeights["volumes"])
+	addView(g, "containers", aboveContainersView, titles["containers"], vHeights["containers"])
+	addView(g, "images", "containers", titles["images"], vHeights["images"])
+	addView(g, "volumes", "images", titles["volumes"], vHeights["volumes"])
 
 	if v, err := g.SetView("options", appStatusOptionsBoundary-1, height-2, optionsVersionBoundary-1, height, 0); err != nil {
 		if err.Error() != "unknown view" {

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -204,14 +204,15 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 	}
 
 	aboveContainersView := "project"
-	if showServicesPanel {
-		aboveContainersView = "services"
-		addView(g, "services", "project", titles["services"], vHeights["services"])
+	for _, view := range gui.CyclableViews {
+		if view == aboveContainersView {
+			continue
+		}
+		if err = addView(g, view, aboveContainersView, titles[view], vHeights[view]); err != nil {
+			return err
+		}
+		aboveContainersView = view
 	}
-
-	addView(g, "containers", aboveContainersView, titles["containers"], vHeights["containers"])
-	addView(g, "images", "containers", titles["images"], vHeights["images"])
-	addView(g, "volumes", "images", titles["volumes"], vHeights["volumes"])
 
 	if v, err := g.SetView("options", appStatusOptionsBoundary-1, height-2, optionsVersionBoundary-1, height, 0); err != nil {
 		if err.Error() != "unknown view" {

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -195,21 +195,20 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		titles["containers"] = gui.Tr.ContainersTitle
 	}
 
-	if v, err := g.SetView("project", 0, 0, leftSideWidth, vHeights["project"]-1, gocui.BOTTOM|gocui.RIGHT); err != nil {
-		if err.Error() != "unknown view" {
-			return err
-		}
-		v.Title = titles["project"]
-		v.FgColor = gocui.ColorDefault
-	}
-
-	aboveContainersView := "project"
+	aboveContainersView := ""
 	for _, view := range gui.CyclableViews {
-		if view == aboveContainersView {
-			continue
-		}
-		if err = addView(g, view, aboveContainersView, titles[view], vHeights[view]); err != nil {
-			return err
+		if aboveContainersView == "" {
+			if v, err := g.SetView(view, 0, 0, leftSideWidth, vHeights[view]-1, gocui.BOTTOM|gocui.RIGHT); err != nil {
+				if err.Error() != "unknown view" {
+					return err
+				}
+				v.Title = titles[view]
+				v.FgColor = gocui.ColorDefault
+			}
+		} else {
+			if err = addView(g, view, aboveContainersView, titles[view], vHeights[view]); err != nil {
+				return err
+			}
 		}
 		aboveContainersView = view
 	}

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -93,6 +93,14 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 		return nil
 	}
 
+	// TODO: should do this once only..
+	showServicesPanel := false
+	for _, view := range gui.CyclableViews {
+		if view == "services" {
+			showServicesPanel = true
+		}
+	}
+
 	currView := gui.g.CurrentView()
 	currentCyclebleView := gui.State.PreviousView
 	if currView != nil {
@@ -114,7 +122,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 
 	tallPanels := 3
 	var vHeights map[string]int
-	if gui.DockerCommand.InDockerComposeProject {
+	if showServicesPanel {
 		tallPanels++
 		vHeights = map[string]int{
 			"project":    3,
@@ -146,7 +154,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 			"volumes":    defaultHeight,
 			"options":    defaultHeight,
 		}
-		if gui.DockerCommand.InDockerComposeProject {
+		if showServicesPanel {
 			vHeights["services"] = defaultHeight
 		}
 		vHeights[currentCyclebleView] = height - defaultHeight*tallPanels - 1
@@ -186,7 +194,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 
 	var servicesView *gocui.View
 	aboveContainersView := "project"
-	if gui.DockerCommand.InDockerComposeProject {
+	if showServicesPanel {
 		aboveContainersView = "services"
 		servicesView, err = g.SetViewBeneath("services", "project", vHeights["services"])
 		if err != nil {
@@ -205,7 +213,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 			return err
 		}
 		containersView.Highlight = true
-		if gui.Config.UserConfig.Gui.ShowAllContainers || !gui.DockerCommand.InDockerComposeProject {
+		if gui.Config.UserConfig.Gui.ShowAllContainers || !showServicesPanel {
 			containersView.Title = gui.Tr.ContainersTitle
 		} else {
 			containersView.Title = gui.Tr.StandaloneContainersTitle

--- a/pkg/gui/project_panel.go
+++ b/pkg/gui/project_panel.go
@@ -34,8 +34,8 @@ func (gui *Gui) refreshProject() error {
 	projectName := path.Base(gui.Config.ProjectDir)
 	if gui.DockerCommand.InDockerComposeProject {
 		for _, service := range gui.DockerCommand.Services {
-			if service.Container != nil {
-				projectName = service.Container[0].Details.Config.Labels["com.docker.compose.project"]
+			if len(service.Containers) > 0 {
+				projectName = service.Containers[0].Details.Config.Labels["com.docker.compose.project"]
 				break
 			}
 		}

--- a/pkg/gui/project_panel.go
+++ b/pkg/gui/project_panel.go
@@ -35,7 +35,7 @@ func (gui *Gui) refreshProject() error {
 	if gui.DockerCommand.InDockerComposeProject {
 		for _, service := range gui.DockerCommand.Services {
 			if service.Container != nil {
-				projectName = service.Container.Details.Config.Labels["com.docker.compose.project"]
+				projectName = service.Container[0].Details.Config.Labels["com.docker.compose.project"]
 				break
 			}
 		}

--- a/pkg/gui/services_panel.go
+++ b/pkg/gui/services_panel.go
@@ -47,7 +47,7 @@ func (gui *Gui) handleServiceSelect(g *gocui.Gui, v *gocui.View) error {
 
 	containerID := ""
 	if service.Container != nil {
-		containerID = service.Container.ID
+		containerID = service.Container[0].ID
 	}
 
 	if err := gui.focusPoint(0, gui.State.Panels.Services.SelectedLine, len(gui.DockerCommand.Services), v); err != nil {
@@ -77,7 +77,7 @@ func (gui *Gui) handleServiceSelect(g *gocui.Gui, v *gocui.View) error {
 		if service.Container == nil {
 			return gui.renderString(gui.g, "main", gui.Tr.NoContainer)
 		}
-		if err := gui.renderContainerConfig(service.Container); err != nil {
+		if err := gui.renderContainerConfig(service.Container[0]); err != nil {
 			return err
 		}
 	case "top":
@@ -92,11 +92,11 @@ func (gui *Gui) handleServiceSelect(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (gui *Gui) renderServiceStats(service *commands.Service) error {
-	if service.Container == nil {
+	if len(service.Container) == 0 {
 		return nil
 	}
 
-	return gui.renderContainerStats(service.Container)
+	return gui.renderContainerStats(service.Container[0])
 }
 
 func (gui *Gui) renderServiceTop(service *commands.Service) error {
@@ -120,13 +120,13 @@ func (gui *Gui) renderServiceLogs(service *commands.Service) error {
 		return nil
 	}
 
-	if service.Container == nil {
+	if len(service.Container) == 0 {
 		return gui.T.NewTask(func(stop chan struct{}) {
 			gui.clearMainView()
 		})
 	}
 
-	return gui.renderContainerLogs(service.Container)
+	return gui.renderContainerLogs(service.Container[0])
 }
 
 func (gui *Gui) handleServicesNextLine(g *gocui.Gui, v *gocui.View) error {
@@ -374,7 +374,7 @@ func (gui *Gui) handleServicesCustomCommand(g *gocui.Gui, v *gocui.View) error {
 
 	commandObject := gui.DockerCommand.NewCommandObject(commands.CommandObject{
 		Service:   service,
-		Container: service.Container,
+		Container: service.Container[0],
 	})
 
 	var customCommands []config.CustomCommand

--- a/pkg/gui/services_panel.go
+++ b/pkg/gui/services_panel.go
@@ -46,8 +46,8 @@ func (gui *Gui) handleServiceSelect(g *gocui.Gui, v *gocui.View) error {
 	}
 
 	containerID := ""
-	if service.Container != nil {
-		containerID = service.Container[0].ID
+	if len(service.Containers) > 0 {
+		containerID = service.Containers[0].ID
 	}
 
 	if err := gui.focusPoint(0, gui.State.Panels.Services.SelectedLine, len(gui.DockerCommand.Services), v); err != nil {
@@ -74,10 +74,10 @@ func (gui *Gui) handleServiceSelect(g *gocui.Gui, v *gocui.View) error {
 			return err
 		}
 	case "container-config":
-		if service.Container == nil {
+		if len(service.Containers) == 0 {
 			return gui.renderString(gui.g, "main", gui.Tr.NoContainer)
 		}
-		if err := gui.renderContainerConfig(service.Container[0]); err != nil {
+		if err := gui.renderContainerConfig(service.Containers[0]); err != nil {
 			return err
 		}
 	case "top":
@@ -92,11 +92,11 @@ func (gui *Gui) handleServiceSelect(g *gocui.Gui, v *gocui.View) error {
 }
 
 func (gui *Gui) renderServiceStats(service *commands.Service) error {
-	if len(service.Container) == 0 {
+	if len(service.Containers) == 0 {
 		return nil
 	}
 
-	return gui.renderContainerStats(service.Container[0])
+	return gui.renderContainerStats(service.Containers[0])
 }
 
 func (gui *Gui) renderServiceTop(service *commands.Service) error {
@@ -120,13 +120,13 @@ func (gui *Gui) renderServiceLogs(service *commands.Service) error {
 		return nil
 	}
 
-	if len(service.Container) == 0 {
+	if len(service.Containers) == 0 {
 		return gui.T.NewTask(func(stop chan struct{}) {
 			gui.clearMainView()
 		})
 	}
 
-	return gui.renderContainerLogs(service.Container[0])
+	return gui.renderContainerLogs(service.Containers[0])
 }
 
 func (gui *Gui) handleServicesNextLine(g *gocui.Gui, v *gocui.View) error {
@@ -252,7 +252,7 @@ func (gui *Gui) handleServiceAttach(g *gocui.Gui, v *gocui.View) error {
 		return nil
 	}
 
-	if service.Container == nil {
+	if len(service.Containers) == 0 {
 		return gui.createErrorPanel(gui.g, gui.Tr.NoContainers)
 	}
 
@@ -374,7 +374,7 @@ func (gui *Gui) handleServicesCustomCommand(g *gocui.Gui, v *gocui.View) error {
 
 	commandObject := gui.DockerCommand.NewCommandObject(commands.CommandObject{
 		Service:   service,
-		Container: service.Container[0],
+		Container: service.Containers[0],
 	})
 
 	var customCommands []config.CustomCommand
@@ -396,7 +396,7 @@ L:
 		}
 	}
 
-	if service.Container != nil {
+	if len(service.Containers) > 0 {
 		customCommands = append(customCommands, gui.Config.UserConfig.CustomCommands.Containers...)
 	}
 


### PR DESCRIPTION
So I thought I'd noodle around with making lazydocker work with docker swarm, and it kinda works, but needs more

the config I'm using atm is

```
commandTemplates:
  dockerCompose: docker-compose
  restartService: '{{ .DockerCompose }} restart {{ .Service.Name }}'
  stopService: '{{ .DockerCompose }} stop {{ .Service.Name }}'
  serviceLogs: '{{ .DockerCompose }} logs --since=60m --follow {{ .Service.Name }}'
  viewServiceLogs: '{{ .DockerCompose }} logs --follow {{ .Service.Name }}'
  rebuildService: '{{ .DockerCompose }} up -d --build {{ .Service.Name }}'
  recreateService: '{{ .DockerCompose }} up -d --force-recreate {{ .Service.Name }}'
  viewContainerLogs: docker logs --timestamps --follow --since=60m {{ .Container.ID
    }}
  containerLogs: docker logs --timestamps --follow --since=60m {{ .Container.ID }}
  allLogs: '{{ .DockerCompose }} logs --tail=300 --follow'
  viewAlLogs: '{{ .DockerCompose }} logs'
  dockerComposeConfig: '{{ .DockerCompose }} config'
  checkDockerComposeConfig: 'true'
  serviceTop: 'docker service ps --no-trunc {{ .Service.Name }}'

  dockerComposeConfigHash: 'docker service ls --format "{{.Name}} {{.ID}}"'

```

**Big TODOs:** 
1 right now, there seems to be an assumption that there's only one container per service - i don't use compose, but I think even there, you can scale a service to have more than one container.
2 once you can have more than one container per service, we need a way for it to be multi-docker daemon/host aware... (can only inspect / exec into containers that are local atm)

for #47