### PR TITLE
custom commands for images and volumes

### DIFF
--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -51,6 +51,8 @@ type CommandObject struct {
 	DockerCompose string
 	Service       *Service
 	Container     *Container
+	Image         *Image
+	Volume        *Volume
 }
 
 // NewCommandObject takes a command object and returns a default command object with the passed command object merged in

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -258,6 +258,12 @@ type CustomCommands struct {
 
 	// Services contains the custom commands for services
 	Services []CustomCommand `yaml:"services,omitempty"`
+
+	// Services contains the custom commands for services
+	Images []CustomCommand `yaml:"images,omitempty"`
+
+	// Services contains the custom commands for services
+	Volumes []CustomCommand `yaml:"volumes,omitempty"`
 }
 
 // CustomCommand is a template for a command we want to run against a service or
@@ -335,6 +341,8 @@ func GetDefaultConfig() UserConfig {
 				},
 			},
 			Services: []CustomCommand{},
+			Images:   []CustomCommand{},
+			Volumes:  []CustomCommand{},
 		},
 		OS: GetPlatformDefaultConfig(),
 		Update: UpdateConfig{

--- a/pkg/gui/images_panel.go
+++ b/pkg/gui/images_panel.go
@@ -259,3 +259,19 @@ func (gui *Gui) handlePruneImages(g *gocui.Gui, v *gocui.View) error {
 		})
 	}, nil)
 }
+
+func (gui *Gui) handleImagesCustomCommand(g *gocui.Gui, v *gocui.View) error {
+	image, err := gui.getSelectedImage(g)
+	if err != nil {
+		return nil
+	}
+
+	commandObject := gui.DockerCommand.NewCommandObject(
+		commands.CommandObject{
+			Image: image,
+		})
+
+	customCommands := gui.Config.UserConfig.CustomCommands.Images
+
+	return gui.createCustomCommandMenu(customCommands, commandObject)
+}

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -339,6 +339,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		},
 		{
 			ViewName:    "images",
+			Key:         'c',
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleImagesCustomCommand,
+			Description: gui.Tr.RunCustomCommand,
+		},
+		{
+			ViewName:    "images",
 			Key:         'd',
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleImagesRemoveMenu,
@@ -364,6 +371,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleVolumesNextContext,
 			Description: gui.Tr.NextContext,
+		},
+		{
+			ViewName:    "volumes",
+			Key:         'c',
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleVolumesCustomCommand,
+			Description: gui.Tr.RunCustomCommand,
 		},
 		{
 			ViewName:    "volumes",

--- a/pkg/gui/volumes_panel.go
+++ b/pkg/gui/volumes_panel.go
@@ -250,3 +250,19 @@ func (gui *Gui) handlePruneVolumes(g *gocui.Gui, v *gocui.View) error {
 		})
 	}, nil)
 }
+
+func (gui *Gui) handleVolumesCustomCommand(g *gocui.Gui, v *gocui.View) error {
+	volume, err := gui.getSelectedVolume()
+	if err != nil {
+		return nil
+	}
+
+	commandObject := gui.DockerCommand.NewCommandObject(
+		commands.CommandObject{
+			Volume: volume,
+		})
+
+	customCommands := gui.Config.UserConfig.CustomCommands.Volumes
+
+	return gui.createCustomCommandMenu(customCommands, commandObject)
+}


### PR DESCRIPTION
so while noodling around with swarm support, I also wondered about custom command support - and added image and volume commands

config:

```
customCommands:
  containers:
  - name: bash
    attach: true
    command: docker exec -it {{ .Container.ID }} /bin/sh
    serviceNames: []
  images:
  - name: run
    attach: true
    command: docker run --rm -it {{ .Image.Name }}:{{.Image.Tag}}
    serviceNames: []
  - name: run with sh
    attach: true
    command: docker run --rm -it --entrypoint sh {{ .Image.Name }}:{{.Image.Tag}}
    serviceNames: []
  volumes:
  - name: shell in volume
    attach: true
    command: docker run --rm -it -v {{ .Volume.Name }}:/data -w /data alpine /bin/sh
    serviceNames: []
```