### PR TITLE
Allow user setting the pull interval

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -53,9 +53,7 @@ oS:
   openCommand: open {{filename}}
   openLinkCommand: open {{link}}
 update:
-  refreshProjectTime: 100ms
-  refreshContainersAndServicesTime: 100ms
-  refreshVolumesTime: 100ms
+  dockerRefreshInterval: 100ms
   method: never
 stats:
   graphs:

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -13,7 +13,7 @@ Changes to the user config will only take place after closing and re-opening laz
 
 ## Default:
 
-```
+```yml
 gui:
   scrollHeight: 2
   theme:
@@ -53,6 +53,9 @@ oS:
   openCommand: open {{filename}}
   openLinkCommand: open {{link}}
 update:
+  refreshProjectTime: 100ms
+  refreshContainersAndServicesTime: 100ms
+  refreshVolumesTime: 100ms
   method: never
 stats:
   graphs:

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -54,7 +54,6 @@ oS:
   openLinkCommand: open {{link}}
 update:
   dockerRefreshInterval: 100ms
-  method: never
 stats:
   graphs:
   - caption: CPU (%)

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -53,8 +53,7 @@ type UserConfig struct {
 	// OS determines what defaults are set for opening files and links
 	OS OSConfig `yaml:"oS,omitempty"`
 
-	// Update is currently not being used, but like lazydocker, it may be used down
-	// the line to help you update automatically.
+	// UpdateConfig determines what the default settings are for updating the ui
 	Update UpdateConfig `yaml:"update,omitempty"`
 
 	// Stats determines how long lazydocker will gather container stats for, and
@@ -191,10 +190,21 @@ type OSConfig struct {
 	OpenLinkCommand string `yaml:"openLinkCommand,omitempty"`
 }
 
-// UpdateConfig is currently not being used, but may be used down the line to
-// allow for automatic updates
+// UpdateConfig determines what the default settings are for updating the ui
+//
+// For the RefreshProjectTime, RefreshContainersAndServicesTime and RefreshVolumesTime
+// the application expects a valid duration like: 100ms, 2s, 200ns
+// for docs see: https://golang.org/pkg/time/#ParseDuration
 type UpdateConfig struct {
-	Method string `yaml:"method,omitempty"`
+	// RefreshProjectTime determines the time betweens updates of the project panel
+	RefreshProjectTime string `yaml:"refreshProjectTime,omitempty"`
+
+	// RefreshContainersAndServicesTime determines the time betweens updates of the containers and services panel
+	RefreshContainersAndServicesTime string `yaml:"refreshContainersAndServicesTime,omitempty"`
+
+	// RefreshVolumesTime determines the time betweens updates of the volumes panel
+	RefreshVolumesTime string `yaml:"refreshVolumesTime,omitempty"`
+	Method             string `yaml:"method,omitempty"`
 }
 
 // GraphConfig specifies how to make a graph of recorded container stats
@@ -346,7 +356,10 @@ func GetDefaultConfig() UserConfig {
 		},
 		OS: GetPlatformDefaultConfig(),
 		Update: UpdateConfig{
-			Method: "never",
+			RefreshProjectTime:               "100ms",
+			RefreshContainersAndServicesTime: "100ms",
+			RefreshVolumesTime:               "100ms",
+			Method:                           "never",
 		},
 		Stats: StatsConfig{
 			MaxDuration: duration,

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -196,7 +196,6 @@ type UpdateConfig struct {
 	// It expects a valid duration like: 100ms, 2s, 200ns
 	// for docs see: https://golang.org/pkg/time/#ParseDuration
 	DockerRefreshInterval time.Duration `yaml:"dockerRefreshInterval,omitempty"`
-	Method                string        `yaml:"method,omitempty"`
 }
 
 // GraphConfig specifies how to make a graph of recorded container stats
@@ -349,7 +348,6 @@ func GetDefaultConfig() UserConfig {
 		OS: GetPlatformDefaultConfig(),
 		Update: UpdateConfig{
 			DockerRefreshInterval: time.Millisecond * 100,
-			Method:                "never",
 		},
 		Stats: StatsConfig{
 			MaxDuration: duration,

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -191,20 +191,12 @@ type OSConfig struct {
 }
 
 // UpdateConfig determines what the default settings are for updating the ui
-//
-// For the RefreshProjectTime, RefreshContainersAndServicesTime and RefreshVolumesTime
-// the application expects a valid duration like: 100ms, 2s, 200ns
-// for docs see: https://golang.org/pkg/time/#ParseDuration
 type UpdateConfig struct {
-	// RefreshProjectTime determines the time betweens updates of the project panel
-	RefreshProjectTime string `yaml:"refreshProjectTime,omitempty"`
-
-	// RefreshContainersAndServicesTime determines the time betweens updates of the containers and services panel
-	RefreshContainersAndServicesTime string `yaml:"refreshContainersAndServicesTime,omitempty"`
-
-	// RefreshVolumesTime determines the time betweens updates of the volumes panel
-	RefreshVolumesTime string `yaml:"refreshVolumesTime,omitempty"`
-	Method             string `yaml:"method,omitempty"`
+	// RefreshProjectTime determines the time betweens updates of all continues docker commands like docker ps, docker images, etc.
+	// It expects a valid duration like: 100ms, 2s, 200ns
+	// for docs see: https://golang.org/pkg/time/#ParseDuration
+	DockerRefreshInterval time.Duration `yaml:"dockerRefreshInterval,omitempty"`
+	Method                string        `yaml:"method,omitempty"`
 }
 
 // GraphConfig specifies how to make a graph of recorded container stats
@@ -356,10 +348,8 @@ func GetDefaultConfig() UserConfig {
 		},
 		OS: GetPlatformDefaultConfig(),
 		Update: UpdateConfig{
-			RefreshProjectTime:               "100ms",
-			RefreshContainersAndServicesTime: "100ms",
-			RefreshVolumesTime:               "100ms",
-			Method:                           "never",
+			DockerRefreshInterval: time.Millisecond * 100,
+			Method:                "never",
 		},
 		Stats: StatsConfig{
 			MaxDuration: duration,

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -267,34 +267,14 @@ func (gui *Gui) Run() error {
 		gui.waitForIntro.Add(1)
 	}
 
-	updates := gui.Config.UserConfig.Update
-	projectDuration := time.Millisecond * 100
-	containersAndServicesDuration := time.Millisecond * 100
-	volumesDuration := time.Millisecond * 100
-	toBind := []struct {
-		BindTo *time.Duration
-		Value  string
-	}{
-		{&projectDuration, updates.RefreshProjectTime},
-		{&containersAndServicesDuration, updates.RefreshContainersAndServicesTime},
-		{&volumesDuration, updates.RefreshVolumesTime},
-	}
-	for _, item := range toBind {
-		duration, err := time.ParseDuration(item.Value)
-		if err == nil {
-			*item.BindTo = duration
-			continue
-		}
-		gui.Log.Error("Can't parse duration:", err)
-	}
-
+	dockerRefreshInterval := gui.Config.UserConfig.Update.DockerRefreshInterval
 	go func() {
 		gui.waitForIntro.Wait()
 		gui.goEvery(time.Millisecond*50, gui.renderAppStatus)
 		gui.goEvery(time.Millisecond*30, gui.reRenderMain)
-		gui.goEvery(projectDuration, gui.refreshProject)
-		gui.goEvery(containersAndServicesDuration, gui.refreshContainersAndServices)
-		gui.goEvery(volumesDuration, gui.refreshVolumes)
+		gui.goEvery(dockerRefreshInterval, gui.refreshProject)
+		gui.goEvery(dockerRefreshInterval, gui.refreshContainersAndServices)
+		gui.goEvery(dockerRefreshInterval, gui.refreshVolumes)
 		gui.goEvery(time.Millisecond*1000, gui.DockerCommand.UpdateContainerDetails)
 		gui.goEvery(time.Millisecond*1000, gui.checkForContextChange)
 	}()


### PR DESCRIPTION
This fixes #115,  
With this you can add:  
```yml
update:
  refreshProjectTime: 100ms
  refreshContainersAndServicesTime: 100ms
  refreshVolumesTime: 100ms
```
To the lazydocker config to change the pull timing.  