### PR TITLE
Removed unnecessary string conversion

### DIFF
--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -146,7 +146,7 @@ func TestResolvePlaceholderString(t *testing.T) {
 	}
 
 	for _, s := range scenarios {
-		assert.EqualValues(t, string(s.expected), ResolvePlaceholderString(s.templateString, s.arguments))
+		assert.EqualValues(t, s.expected, ResolvePlaceholderString(s.templateString, s.arguments))
 	}
 }
 


### PR DESCRIPTION
`s.expected` is already a string.