### PR TITLE
ensure the current task is stopped before exit

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -161,7 +161,7 @@ func NewGui(log *logrus.Entry, dockerCommand *commands.DockerCommand, oSCommand 
 		Config:        config,
 		Tr:            tr,
 		statusManager: &statusManager{},
-		T:             tasks.NewTaskManager(log),
+		T:             tasks.NewTaskManager(log, tr),
 		ErrorChan:     errorChan,
 		CyclableViews: cyclableViews,
 	}
@@ -245,6 +245,9 @@ func (gui *Gui) goEvery(interval time.Duration, function func() error) {
 
 // Run setup the gui with keybindings and start the mainloop
 func (gui *Gui) Run() error {
+	// closing our task manager which in turn closes the current task if there is any, so we aren't leaving processes lying around after closing lazydocker
+	defer gui.T.Close()
+
 	g, err := gocui.NewGui(gocui.OutputNormal, OverlappingEdges)
 	if err != nil {
 		return err

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -24,6 +24,7 @@ type TranslationSet struct {
 	UnattachableContainerError                 string
 	CannotAttachStoppedContainerError          string
 	CannotAccessDockerSocketError              string
+	CannotKillChildError                       string
 
 	Donate                     string
 	Cancel                     string
@@ -110,6 +111,7 @@ func englishSet() TranslationSet {
 		UnattachableContainerError:        "Container does not support attaching. You must either run the service with the '-it' flag or use `stdin_open: true, tty: true` in the docker-compose.yml file",
 		CannotAttachStoppedContainerError: "You cannot attach to a stopped container, you need to start it first (which you can actually do with the 'r' key) (yes I'm too lazy to do this automatically for you) (pretty cool that I get to communicate one-on-one with you in the form of an error message though)",
 		CannotAccessDockerSocketError:     "Can't access docker socket at: unix:///var/run/docker.sock\nRun lazydocker as root or read https://docs.docker.com/install/linux/linux-postinstall/",
+		CannotKillChildError:              "Waited three seconds for child process to stop. There may be an orphan process that continues to run on your system.",
 
 		Donate:  "Donate",
 		Confirm: "Confirm",


### PR DESCRIPTION
fixes https://github.com/jesseduffield/lazydocker/issues/147 (kinda)

For some reason we have child processes that are not being killed when lazydocker exits. To fix this, I'm making it so that before closing, lazydocker kills its task manager, which in turn kills the current task if there is any (e.g. `docker logs <container id>`). If the child process isn't killed in three seconds, it prints an error to stdout.

I have no idea why the child processes are not being killed when the parent is stopped in the first place. I considered maybe their group id is different, given we assign a group id to some subprocesses like `docker-compose logs`, but it seems that's not the case with `docker logs`. I am open to suggestions :)