### PR TITLE
Remove the containers once you exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ A development version of the AUR package is also [available](https://aur.archlin
 1. Run the container
 
     ```sh
-    docker run -it -v \
+    docker run --rm -it -v \
     /var/run/docker.sock:/var/run/docker.sock \
     -v /yourpath:/.config/jesseduffield/lazydocker \
     lazyteam/lazydocker
@@ -138,7 +138,7 @@ A development version of the AUR package is also [available](https://aur.archlin
     - You might want to create an alias, for example:
 
         ```sh
-        echo "alias lzd='docker run -it -v /var/run/docker.sock:/var/run/docker.sock -v /yourpath/config:/.config/jesseduffield/lazydocker lazyteam/lazydocker'" >> ~/.zshrc
+        echo "alias lzd='docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -v /yourpath/config:/.config/jesseduffield/lazydocker lazyteam/lazydocker'" >> ~/.zshrc
         ```
 
 


### PR DESCRIPTION
Exiting after using `docker run` leaves behind stopped containers. Adding `--rm` tells Docker to delete them after exiting.