### PR TITLE
Removed unconditional logging profile

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -15,7 +15,7 @@ import (
 func NewLogger(config *config.AppConfig, rollrusHook string) *logrus.Entry {
 	var log *logrus.Logger
 	environment := "production"
-	if true || config.Debug || os.Getenv("DEBUG") == "TRUE" { // TODO: remove true here
+	if config.Debug || os.Getenv("DEBUG") == "TRUE" {
 		environment = "development"
 		log = newDevelopmentLogger(config)
 	} else {


### PR DESCRIPTION
The `lazydocker` application will respect the given profile when it comes to logging.