### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,9 @@ In the future I want to make this the default, but for now there are some CPU is
 
 ### How do you select text?
 
-Because we support mouse events, you will need to hold option while dragging the mouse to indicate you're trying to select text rather than click on something. Alternatively you can disable mouse events via the `gui.ignoreMouseEvents` config value
+Because we support mouse events, you will need to hold option while dragging the mouse to indicate you're trying to select text rather than click on something. Alternatively you can disable mouse events via the `gui.ignoreMouseEvents` config value.
+
+Mac Users: See [Issue #190](https://github.com/jesseduffield/lazydocker/issues/190) for other options.
 
 ### Why can't I see my container's logs?
 


### PR DESCRIPTION
- Link to an issue with instructions on how to copy-paste text on a Mac

* Not adding all the instructions directly into the README to avoid bloat