### PR TITLE
Add health check to container list

### DIFF
--- a/pkg/commands/container.go
+++ b/pkg/commands/container.go
@@ -261,7 +261,7 @@ func (c *Container) GetDisplayStatus() string {
 		state += " (" + strconv.Itoa(c.Details.State.ExitCode) + ")"
 	}
 	if c.Container.State == "running" && c.Details.State.Health.Status != "" {
-		state += " (" + c.Details.State.Health.Status + ")";
+		state += " (" + c.Details.State.Health.Status + ")"
 	}
 	if c.Container.State == "running" && c.Details.State.Health.Status == "unhealthy" {
 		return utils.MultiColoredString(state, c.GetColor(), color.BgRed)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -52,6 +52,13 @@ func ColoredString(str string, colorAttribute color.Attribute) string {
 	return ColoredStringDirect(str, colour)
 }
 
+// MultiColoredString takes a string and an array of colour attributes and returns a colored
+// string with those attributes
+func MultiColoredString(str string, colorAttribute ...color.Attribute) string {
+	colour := color.New(colorAttribute...)
+	return ColoredStringDirect(str, colour)
+}
+
 // ColoredStringDirect used for aggregating a few color attributes rather than
 // just sending a single one
 func ColoredStringDirect(str string, colour *color.Color) string {


### PR DESCRIPTION
If container has health check configured, it will display with container status e.g. "running (healthy)".

Also I added a utility method for adding more than one colour attribute to a string.