### PR TITLE
Fix Logs (and others) tab always being empty

### DIFF
--- a/pkg/gui/containers_panel.go
+++ b/pkg/gui/containers_panel.go
@@ -186,6 +186,11 @@ func (gui *Gui) renderContainerLogs(container *commands.Container) error {
 		)
 		cmd := gui.OSCommand.RunCustomCommand(command)
 
+		// Ensure the child process is treated as a group, as the child process spawns
+		// its own children. Termination requires sending the signal to the group
+		// process ID.
+		gui.OSCommand.PrepareForChildren(cmd)
+
 		mainView := gui.getMainView()
 		cmd.Stdout = mainView
 		cmd.Stderr = mainView


### PR DESCRIPTION
Lazydocker was not flagging the `docker logs` process as a group, so the `kill` signal failed to kill all the children. As such, certain goroutines never exited, and the gui was unable to update or spawn new children.

Fixes #218 #239 #240 