### PR TITLE
Open in browser

### DIFF
--- a/pkg/gui/containers_panel.go
+++ b/pkg/gui/containers_panel.go
@@ -571,3 +571,26 @@ func (gui *Gui) handleContainersBulkCommand(g *gocui.Gui, v *gocui.View) error {
 
 	return gui.createBulkCommandMenu(bulkCommands, commandObject)
 }
+
+// Open first port in browser
+func (gui *Gui) handleContainersOpenInBrowserCommand(g *gocui.Gui, v *gocui.View) error {
+	container, err := gui.getSelectedContainer()
+	if err != nil {
+		return nil
+	}
+	// skip if no any ports
+	if len(container.Container.Ports) == 0 {
+		return nil
+	}
+	// skip if the first port is not published
+	port := container.Container.Ports[0]
+	if port.IP == "" {
+		return nil
+	}
+	ip := port.IP
+	if ip == "0.0.0.0" {
+		ip = "localhost"
+	}
+	link := fmt.Sprintf("http://%s:%d/", ip, port.PublicPort)
+	return gui.OSCommand.OpenLink(link)
+}

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -263,6 +263,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Description: gui.Tr.ViewBulkCommands,
 		},
 		{
+			ViewName:    "containers",
+			Key:         'w',
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleContainersOpenInBrowserCommand,
+			Description: gui.Tr.OpenInBrowser,
+		},
+		{
 			ViewName:    "services",
 			Key:         'd',
 			Modifier:    gocui.ModNone,

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -82,6 +82,7 @@ type TranslationSet struct {
 	ViewRestartOptions         string
 	RunCustomCommand           string
 	ViewBulkCommands           string
+	OpenInBrowser              string
 
 	LogsTitle                string
 	ConfigTitle              string
@@ -150,6 +151,7 @@ func englishSet() TranslationSet {
 		ViewRestartOptions:  "view restart options",
 		RunCustomCommand:    "run predefined custom command",
 		ViewBulkCommands:    "view bulk commands",
+		OpenInBrowser:       "open in browser (first port is http)",
 
 		AnonymousReportingTitle:  "Help make lazydocker better",
 		AnonymousReportingPrompt: "Would you like to enable anonymous reporting data to help improve lazydocker?",


### PR DESCRIPTION
Most containers expose some http port. We can open it in browser.
For simplicity we can just open first container's published port.

The same feature already exists in DockerStation