### PR TITLE
Open service in browser

### DIFF
--- a/docs/keybindings/Keybindings_de.md
+++ b/docs/keybindings/Keybindings_de.md
@@ -42,6 +42,7 @@
   <kbd>R</kbd>: zeige Neustartoptionen
   <kbd>c</kbd>: führe vordefinierten benutzerdefinierten Befehl aus
   <kbd>b</kbd>: view bulk commands
+  <kbd>w</kbd>: open in browser (first port is http)
   <kbd>enter</kbd>: fokussieren aufs Hauptpanel
 </pre>
 

--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -42,6 +42,7 @@
   <kbd>R</kbd>: view restart options
   <kbd>c</kbd>: run predefined custom command
   <kbd>b</kbd>: view bulk commands
+  <kbd>w</kbd>: open in browser (first port is http)
   <kbd>enter</kbd>: focus main panel
 </pre>
 

--- a/docs/keybindings/Keybindings_nl.md
+++ b/docs/keybindings/Keybindings_nl.md
@@ -42,6 +42,7 @@
   <kbd>R</kbd>: bekijk herstart opties
   <kbd>c</kbd>: draai een vooraf bedacht aangepaste opdracht
   <kbd>b</kbd>: view bulk commands
+  <kbd>w</kbd>: open in browser (first port is http)
   <kbd>enter</kbd>: focus hoofdpaneel
 </pre>
 

--- a/docs/keybindings/Keybindings_pl.md
+++ b/docs/keybindings/Keybindings_pl.md
@@ -42,6 +42,7 @@
   <kbd>R</kbd>: pokaż opcje restartu
   <kbd>c</kbd>: wykonaj predefiniowaną własną komende
   <kbd>b</kbd>: view bulk commands
+  <kbd>w</kbd>: open in browser (first port is http)
   <kbd>enter</kbd>: skup na głównym panelu
 </pre>
 

--- a/docs/keybindings/Keybindings_tr.md
+++ b/docs/keybindings/Keybindings_tr.md
@@ -42,6 +42,7 @@
   <kbd>R</kbd>: yeniden başlatma seçeneklerini görüntüle
   <kbd>c</kbd>: önceden tanımlanmış özel komutu çalıştır
   <kbd>b</kbd>: view bulk commands
+  <kbd>w</kbd>: open in browser (first port is http)
   <kbd>enter</kbd>: ana panele odaklan
 </pre>
 

--- a/pkg/gui/containers_panel.go
+++ b/pkg/gui/containers_panel.go
@@ -593,6 +593,11 @@ func (gui *Gui) handleContainersOpenInBrowserCommand(g *gocui.Gui, v *gocui.View
 	if err != nil {
 		return nil
 	}
+
+	return gui.openContainerInBrowser(container)
+}
+
+func (gui *Gui) openContainerInBrowser(container *commands.Container) error {
 	// skip if no any ports
 	if len(container.Container.Ports) == 0 {
 		return nil

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -347,6 +347,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Description: gui.Tr.ViewBulkCommands,
 		},
 		{
+			ViewName:    "services",
+			Key:         'w',
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleServicesOpenInBrowserCommand,
+			Description: gui.Tr.OpenInBrowser,
+		},
+		{
 			ViewName:    "images",
 			Key:         '[',
 			Modifier:    gocui.ModNone,

--- a/pkg/gui/services_panel.go
+++ b/pkg/gui/services_panel.go
@@ -421,19 +421,5 @@ func (gui *Gui) handleServicesOpenInBrowserCommand(g *gocui.Gui, v *gocui.View) 
 		return gui.createErrorPanel(gui.g, gui.Tr.NoContainers)
 	}
 
-	// skip if no any ports
-	if len(container.Container.Ports) == 0 {
-		return nil
-	}
-	// skip if the first port is not published
-	port := container.Container.Ports[0]
-	if port.IP == "" {
-		return nil
-	}
-	ip := port.IP
-	if ip == "0.0.0.0" {
-		ip = "localhost"
-	}
-	link := fmt.Sprintf("http://%s:%d/", ip, port.PublicPort)
-	return gui.OSCommand.OpenLink(link)
+	return gui.openContainerInBrowser(container)
 }

--- a/pkg/gui/services_panel.go
+++ b/pkg/gui/services_panel.go
@@ -409,3 +409,31 @@ func (gui *Gui) handleServicesBulkCommand(g *gocui.Gui, v *gocui.View) error {
 
 	return gui.createBulkCommandMenu(bulkCommands, commandObject)
 }
+
+func (gui *Gui) handleServicesOpenInBrowserCommand(g *gocui.Gui, v *gocui.View) error {
+	service, err := gui.getSelectedService()
+	if err != nil {
+		return nil
+	}
+
+	container := service.Container
+	if container == nil {
+		return gui.createErrorPanel(gui.g, gui.Tr.NoContainers)
+	}
+
+	// skip if no any ports
+	if len(container.Container.Ports) == 0 {
+		return nil
+	}
+	// skip if the first port is not published
+	port := container.Container.Ports[0]
+	if port.IP == "" {
+		return nil
+	}
+	ip := port.IP
+	if ip == "0.0.0.0" {
+		ip = "localhost"
+	}
+	link := fmt.Sprintf("http://%s:%d/", ip, port.PublicPort)
+	return gui.OSCommand.OpenLink(link)
+}


### PR DESCRIPTION
I really liked new features in 0.12 but unfortunately [Open in browser](#248) doesn't work in services panel.

This PR merely creates the same function for services panel. I took a quick look at `pkg/gui/service_panel.go` and `pkg/gui/containers_panel.go` and used copy-paste with slight adoption like I saw in other functions. Sorry if it was bad approach but I have no prior Go experience 