### PR TITLE
Added link to asdf-vm installation method :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ Automated install/update, don't forget to always verify what you're piping into 
 curl https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/install_update_linux.sh | bash
 ```
 
+#### Or Use [asdf-vm](https://asdf-vm.com/) to install the [asdf-lazydocker plugin](https://github.com/comdotlinux/asdf-lazydocker) once and then keep updating to get the latest version whenever you want.
+```sh
+asdf plugin add https://github.com/comdotlinux/asdf-lazydocker.git
+asdf list all lazydocker
+asdf install lazydocker 0.12
+asdf global lazydocker 0.12
+```
+
 The script installs downloaded binary to `/usr/local/bin` directory by default, but it can be changed by setting `DIR` environment variable.
 
 ### Go

--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ You can install `lazydocker` using [Chocolatey](https://chocolatey.org/):
 ```sh
 choco install lazydocker
 ```
+### asdf-vm
+
+You can install [asdf-lazydocker plugin](https://github.com/comdotlinux/asdf-lazydocker) using [asdf-vm](https://asdf-vm.com/):
+#### Setup (Once)
+```sh
+asdf plugin add https://github.com/comdotlinux/asdf-lazydocker.git
+```
+
+#### For Install / Upgrade
+```sh
+asdf list all lazydocker
+asdf install lazydocker 0.12
+asdf global lazydocker 0.12
+```
 
 ### Binary Release (Linux/OSX/Windows)
 
@@ -81,15 +95,6 @@ Automated install/update, don't forget to always verify what you're piping into 
 ```sh
 curl https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/install_update_linux.sh | bash
 ```
-
-#### Or Use [asdf-vm](https://asdf-vm.com/) to install the [asdf-lazydocker plugin](https://github.com/comdotlinux/asdf-lazydocker) once and then keep updating to get the latest version whenever you want.
-```sh
-asdf plugin add https://github.com/comdotlinux/asdf-lazydocker.git
-asdf list all lazydocker
-asdf install lazydocker 0.12
-asdf global lazydocker 0.12
-```
-
 The script installs downloaded binary to `/usr/local/bin` directory by default, but it can be changed by setting `DIR` environment variable.
 
 ### Go


### PR DESCRIPTION
Since we are using https://asdf-vm.com/#/ to manage versions and I love lazydocker, 
I created a [plugin](https://github.com/comdotlinux/asdf-lazydocker) to help everyone use the same version (that we can then easily keep up-to-date)

This PR just adds some documentation / how-to to use it :) 