### PR TITLE
Add panel navigation to keybindings description

### DIFF
--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -72,5 +72,6 @@
 
 <pre>
   <kbd>esc</kbd>: return
-  <kbd>left/right</kbd> panel navigation
+  <kbd>left</kbd>: previous panel
+  <kbd>right</kbd>: next panel
 </pre>

--- a/docs/keybindings/Keybindings_en.md
+++ b/docs/keybindings/Keybindings_en.md
@@ -72,4 +72,5 @@
 
 <pre>
   <kbd>esc</kbd>: return
+  <kbd>left/right</kbd> panel navigation
 </pre>


### PR DESCRIPTION
@jesseduffield I spent last 15 minutes looking for this information, I tried up/down arrows, tabbing, page up/page down, I looked through the documentation, watched the youtube video, googled, read a few reddit threads, youtube comments, and did multiple searches of the issues. I even remember installing lazydocker a like a year ago and removing it after not finding the panel navigation. This missing info was mentioned in #126 but it was closed without any change.