### PR TITLE
Changes to auto refresh the images every 30s

### DIFF
--- a/pkg/commands/image.go
+++ b/pkg/commands/image.go
@@ -2,11 +2,11 @@ package commands
 
 import (
 	"context"
-	"github.com/docker/docker/api/types/image"
 	"strings"
 
+	"github.com/docker/docker/api/types/image"
+
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/fatih/color"
 	"github.com/jesseduffield/lazydocker/pkg/utils"
@@ -99,51 +99,4 @@ func (i *Image) RenderHistory() (string, error) {
 	}
 
 	return utils.RenderList(layers, utils.WithHeader([]string{"ID", "TAG", "SIZE", "COMMAND"}))
-}
-
-// RefreshImages returns a slice of docker images
-func (c *DockerCommand) RefreshImages() ([]*Image, error) {
-	images, err := c.Client.ImageList(context.Background(), types.ImageListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	ownImages := make([]*Image, len(images))
-
-	for i, image := range images {
-		// func (cli *Client) ImageHistory(ctx context.Context, imageID string) ([]image.HistoryResponseItem, error)
-
-		firstTag := ""
-		tags := image.RepoTags
-		if len(tags) > 0 {
-			firstTag = tags[0]
-		}
-
-		nameParts := strings.Split(firstTag, ":")
-		tag := ""
-		name := "none"
-		if len(nameParts) > 1 {
-			tag = nameParts[len(nameParts)-1]
-			name = strings.Join(nameParts[:len(nameParts)-1], ":")
-		}
-
-		ownImages[i] = &Image{
-			ID:            image.ID,
-			Name:          name,
-			Tag:           tag,
-			Image:         image,
-			Client:        c.Client,
-			OSCommand:     c.OSCommand,
-			Log:           c.Log,
-			DockerCommand: c,
-		}
-	}
-
-	return ownImages, nil
-}
-
-// PruneImages prunes images
-func (c *DockerCommand) PruneImages() error {
-	_, err := c.Client.ImagesPrune(context.Background(), filters.Args{})
-	return err
 }

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -246,6 +246,7 @@ func (gui *Gui) Run() error {
 		gui.goEvery(time.Millisecond*30, gui.reRenderMain)
 		gui.goEvery(dockerRefreshInterval, gui.refreshProject)
 		gui.goEvery(dockerRefreshInterval, gui.refreshContainersAndServices)
+		gui.goEvery(time.Millisecond*30000, gui.refreshImages)
 		gui.goEvery(dockerRefreshInterval, gui.refreshVolumes)
 		gui.goEvery(time.Millisecond*1000, gui.DockerCommand.UpdateContainerDetails)
 		gui.goEvery(time.Millisecond*1000, gui.checkForContextChange)

--- a/pkg/gui/images_panel.go
+++ b/pkg/gui/images_panel.go
@@ -105,7 +105,7 @@ func (gui *Gui) refreshImages() error {
 		// if the ImagesView hasn't been instantiated yet we just return
 		return nil
 	}
-	if err := gui.refreshStateImages(); err != nil {
+	if err := gui.DockerCommand.RefreshImages(); err != nil {
 		return err
 	}
 
@@ -131,18 +131,6 @@ func (gui *Gui) refreshImages() error {
 		}
 		return nil
 	})
-
-	return nil
-}
-
-// TODO: leave this to DockerCommand
-func (gui *Gui) refreshStateImages() error {
-	Images, err := gui.DockerCommand.RefreshImages()
-	if err != nil {
-		return err
-	}
-
-	gui.DockerCommand.Images = Images
 
 	return nil
 }

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -12,9 +12,9 @@ import (
 
 func (gui *Gui) refreshSidePanels(g *gocui.Gui) error {
 	// not refreshing containers and services here given that we do it every few milliseconds anyway
-	if err := gui.refreshImages(); err != nil {
-		return err
-	}
+	// if err := gui.refreshImages(); err != nil {
+	// 	return err
+	// }
 
 	return nil
 }


### PR DESCRIPTION
This PR tries to resolve https://github.com/jesseduffield/lazydocker/issues/260

A couple of Questions:

1. As per the PR I have hardcoded the auto-refresh interval to be 30s, should I make it configurable via config file like how it's done for docker refresh interval
2. Since images are getting refreshed on an interval the function `refreshSidePanels` does not do anything hence I have commented it out, should I remove that function and make changes to any code which calls it?