### PR TITLE
Fix the installed path written in the document to match the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Automated install/update, don't forget to always verify what you're piping into 
 ```sh
 curl https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/install_update_linux.sh | bash
 ```
-The script installs downloaded binary to `/usr/local/bin` directory by default, but it can be changed by setting `DIR` environment variable.
+The script installs downloaded binary to `$HOME/.local/bin` directory by default, but it can be changed by setting `DIR` environment variable.
 
 ### Go
 


### PR DESCRIPTION
First of all, thanks for providing the awesome tool!
This PR fixes the installed path written in the document to match the script.

The description was added on PR https://github.com/jesseduffield/lazydocker/pull/209, and the script was updated on PR https://github.com/jesseduffield/lazydocker/pull/271, but the document was not updated.