### PR TITLE
fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,20 +60,6 @@ jobs:
       - image: circleci/golang:1.17
     steps:
       - checkout
-      #- run:
-      #    name: Install snapcraft
-      #    command: |
-      #      ./.circleci/install_snapcraft.sh
-      #- run:
-      #    name: Login to snapcraft
-      #    # if you ever lose this, you can recreate it via
-      #    # `snapcraft export-login snapcraft.login && base64 snapcraft.login` and then chuck that
-      #    # in circle ci as the SNAPCRAFT_LOGIN_FILE env variable
-      #    # You'll need your ubuntu one password
-      #    command: |
-      #      echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > snapcraft.login
-      #      snapcraft login --with snapcraft.login
-      #      rm snapcraft.login
       - run:
           name: Run gorelease
           command: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ c) if you need to bump a dependency e.g. jesseduffield/gocui, use
 
 ```
 GOFLAGS= go get -u github.com/jesseduffield/gocui@master
+go mod tidy
 go mod vendor
 ```
 
@@ -48,6 +49,7 @@ c) if you need to bump a dependency e.g. jesseduffield/gocui, use
 
 ```
 go get -u github.com/jesseduffield/gocui@master
+go mod tidy
 go mod vendor
 ```
 

--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -74,7 +74,7 @@ func (c *DockerCommand) NewCommandObject(obj CommandObject) CommandObject {
 
 // NewDockerCommand it runs docker commands
 func NewDockerCommand(log *logrus.Entry, osCommand *OSCommand, tr *i18n.TranslationSet, config *config.AppConfig, errorChan chan error) (*DockerCommand, error) {
-	tunnelCloser, err := ssh.NewSSHHandler().HandleSSHDockerHost()
+	tunnelCloser, err := ssh.NewSSHHandler(osCommand).HandleSSHDockerHost()
 	if err != nil {
 		ogLog.Fatal(err)
 	}
@@ -237,7 +237,7 @@ func (c *DockerCommand) RefreshContainersAndServices() error {
 
 	c.assignContainersToServices(containers, services)
 
-	var displayContainers = containers
+	displayContainers := containers
 	if !c.Config.UserConfig.Gui.ShowAllContainers {
 		displayContainers = c.obtainStandaloneContainers(containers, services)
 	}
@@ -468,7 +468,6 @@ func (c *DockerCommand) DockerComposeConfig() string {
 			c.NewCommandObject(CommandObject{}),
 		),
 	)
-
 	if err != nil {
 		output = err.Error()
 	}

--- a/pkg/commands/ssh/ssh_test.go
+++ b/pkg/commands/ssh/ssh_test.go
@@ -65,7 +65,6 @@ func TestSSHHandlerHandleSSHDockerHost(t *testing.T) {
 			startCmdCount := 0
 			startCmd := func(cmd *exec.Cmd) error {
 				assert.EqualValues(t, []string{"ssh", "-L", "/tmp/lazydocker-ssh-tunnel-12345/dockerhost.sock:/var/run/docker.sock", "192.168.5.178", "-N"}, cmd.Args)
-				assert.Equal(t, true, cmd.SysProcAttr.Setpgid)
 
 				startCmdCount++
 
@@ -83,13 +82,13 @@ func TestSSHHandlerHandleSSHDockerHost(t *testing.T) {
 			}
 
 			handler := &SSHHandler{
-				deps: dependencies{
-					dialContext: dialContext,
-					startCmd:    startCmd,
-					tempDir:     tempDir,
-					getenv:      getenv,
-					setenv:      setenv,
-				},
+				oSCommand: &fakeCmdKiller{},
+
+				dialContext: dialContext,
+				startCmd:    startCmd,
+				tempDir:     tempDir,
+				getenv:      getenv,
+				setenv:      setenv,
 			}
 
 			_, err := handler.HandleSSHDockerHost()
@@ -100,3 +99,11 @@ func TestSSHHandlerHandleSSHDockerHost(t *testing.T) {
 		})
 	}
 }
+
+type fakeCmdKiller struct{}
+
+func (self *fakeCmdKiller) Kill(cmd *exec.Cmd) error {
+	return nil
+}
+
+func (self *fakeCmdKiller) PrepareForChildren(cmd *exec.Cmd) {}


### PR DESCRIPTION
Currently our CI fails because windows does not support syscall.Kill, nor does it support SetPgid. This PR instead replaces it with a regular process kill. 

These two things were added in this commit: https://github.com/jesseduffield/lazydocker/commit/892fc090b62bbd9f11156abc5da8201cfe540a1b

But I'm not sure if they're necessary. I want to know whether the ssh command here ever creates its own child processes.

There was some discussion on this here: https://github.com/jesseduffield/lazydocker/pull/268/commits/4e201bb8f44342c3a5900cf286bbbc5343bc4da0#r757413230

I don't have an ssh setup on my own machine so it's tricky for me to test this. @cmoog can I enlist you to take another look at this?

If the PR in its current form has issues we'll need to find a way to do this which is compatible with windows.

See https://github.com/jesseduffield/lazydocker/issues/273 for discussion