### PR TITLE
use alpine that supports go 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE_BUILDER=golang
-ARG ALPINE_VERSION=3.10
+ARG ALPINE_VERSION=3.15
 ARG GO_VERSION=1.18
 
 FROM ${BASE_IMAGE_BUILDER}:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} \
 FROM ${BASE_IMAGE_BUILDER}:${GO_VERSION}-alpine${ALPINE_VERSION} AS docker-builder
 ARG GOARCH=amd64
 ARG GOARM
-ARG DOCKER_VERSION=v18.09.7
+ARG DOCKER_VERSION=v20.10.13
 RUN apk add -U -q --progress --no-cache git bash coreutils gcc musl-dev
 WORKDIR /go/src/github.com/docker/cli
 RUN git clone --branch ${DOCKER_VERSION} --single-branch --depth 1 https://github.com/docker/cli.git . > /dev/null 2>&1


### PR DESCRIPTION
tested via:
```
docker build . -t lazydocker
docker run -it -v /var/run/docker.sock:/var/run/docker.sock lazydocker
```