### PR TITLE
improvements to image view

### DIFF
--- a/pkg/commands/image.go
+++ b/pkg/commands/image.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/docker/docker/api/types/image"
@@ -110,8 +111,6 @@ func (c *DockerCommand) RefreshImages() ([]*Image, error) {
 	ownImages := make([]*Image, len(images))
 
 	for i, image := range images {
-		// func (cli *Client) ImageHistory(ctx context.Context, imageID string) ([]image.HistoryResponseItem, error)
-
 		firstTag := ""
 		tags := image.RepoTags
 		if len(tags) > 0 {
@@ -137,6 +136,20 @@ func (c *DockerCommand) RefreshImages() ([]*Image, error) {
 			DockerCommand: c,
 		}
 	}
+
+	noneLabel := "<none>"
+
+	sort.Slice(ownImages, func(i, j int) bool {
+		if ownImages[i].Name == noneLabel && ownImages[j].Name != noneLabel {
+			return false
+		}
+
+		if ownImages[i].Name != noneLabel && ownImages[j].Name == noneLabel {
+			return true
+		}
+
+		return ownImages[i].Name < ownImages[j].Name
+	})
 
 	return ownImages, nil
 }

--- a/pkg/gui/containers_panel.go
+++ b/pkg/gui/containers_panel.go
@@ -461,16 +461,13 @@ func (gui *Gui) handleContainersRemoveMenu(g *gocui.Gui, v *gocui.View) error {
 					return gui.createConfirmationPanel(gui.g, v, gui.Tr.Confirm, gui.Tr.MustForceToRemoveContainer, func(g *gocui.Gui, v *gocui.View) error {
 						return gui.WithWaitingStatus(gui.Tr.RemovingStatus, func() error {
 							configOptions.Force = true
-							if err := container.Remove(configOptions); err != nil {
-								return err
-							}
-							return gui.refreshContainersAndServices()
+							return container.Remove(configOptions)
 						})
 					}, nil)
 				}
 				return gui.createErrorPanel(gui.g, err.Error())
 			}
-			return gui.refreshContainersAndServices()
+			return nil
 		})
 	}
 
@@ -489,7 +486,7 @@ func (gui *Gui) handleContainerStop(g *gocui.Gui, v *gocui.View) error {
 				return gui.createErrorPanel(gui.g, err.Error())
 			}
 
-			return gui.refreshContainersAndServices()
+			return nil
 		})
 	}, nil)
 }
@@ -505,7 +502,7 @@ func (gui *Gui) handleContainerRestart(g *gocui.Gui, v *gocui.View) error {
 			return gui.createErrorPanel(gui.g, err.Error())
 		}
 
-		return gui.refreshContainersAndServices()
+		return nil
 	})
 }
 

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -183,16 +183,6 @@ func max(a, b int) int {
 	return b
 }
 
-func (gui *Gui) loadNewDirectory() error {
-	gui.waitForIntro.Done()
-
-	if err := gui.refreshSidePanels(gui.g); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (gui *Gui) renderGlobalOptions() error {
 	return gui.renderOptionsMap(map[string]string{
 		"PgUp/PgDn": gui.Tr.Scroll,
@@ -293,13 +283,22 @@ func (gui *Gui) rerenderContainersAndServices() error {
 }
 
 func (gui *Gui) refresh() {
-	gui.refreshProject()
-	if err := gui.refreshContainersAndServices(); err != nil {
-		gui.Log.Error(err)
-	}
-	if err := gui.refreshVolumes(); err != nil {
-		gui.Log.Error(err)
-	}
+	go gui.refreshProject()
+	go func() {
+		if err := gui.refreshContainersAndServices(); err != nil {
+			gui.Log.Error(err)
+		}
+	}()
+	go func() {
+		if err := gui.refreshVolumes(); err != nil {
+			gui.Log.Error(err)
+		}
+	}()
+	go func() {
+		if err := gui.refreshImages(); err != nil {
+			gui.Log.Error(err)
+		}
+	}()
 }
 
 func (gui *Gui) listenForEvents(finish chan struct{}, refresh func()) {

--- a/pkg/gui/images_panel.go
+++ b/pkg/gui/images_panel.go
@@ -240,7 +240,7 @@ func (gui *Gui) handleImagesRemoveMenu(g *gocui.Gui, v *gocui.View) error {
 			return gui.createErrorPanel(gui.g, cerr.Error())
 		}
 
-		return gui.refreshImages()
+		return nil
 	}
 
 	return gui.createMenu("", options, len(options), handleMenuPress)

--- a/pkg/gui/layout.go
+++ b/pkg/gui/layout.go
@@ -256,10 +256,7 @@ func (gui *Gui) layout(g *gocui.Gui) error {
 			return err
 		}
 
-		// doing this here because it'll only happen once
-		if err := gui.loadNewDirectory(); err != nil {
-			return err
-		}
+		gui.waitForIntro.Done()
 	}
 
 	if gui.g.CurrentView() == nil {

--- a/pkg/gui/services_panel.go
+++ b/pkg/gui/services_panel.go
@@ -231,7 +231,7 @@ func (gui *Gui) handleServiceStop(g *gocui.Gui, v *gocui.View) error {
 				return gui.createErrorPanel(gui.g, err.Error())
 			}
 
-			return gui.refreshContainersAndServices()
+			return nil
 		})
 	}, nil)
 }
@@ -247,7 +247,7 @@ func (gui *Gui) handleServiceRestart(g *gocui.Gui, v *gocui.View) error {
 			return gui.createErrorPanel(gui.g, err.Error())
 		}
 
-		return gui.refreshContainersAndServices()
+		return nil
 	})
 }
 

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -10,15 +10,6 @@ import (
 	"github.com/spkg/bom"
 )
 
-func (gui *Gui) refreshSidePanels(g *gocui.Gui) error {
-	// not refreshing containers and services here given that we do it every few milliseconds anyway
-	if err := gui.refreshImages(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (gui *Gui) nextView(g *gocui.Gui, v *gocui.View) error {
 	var focusedViewName string
 	if v == nil || v.Name() == gui.CyclableViews[len(gui.CyclableViews)-1] {


### PR DESCRIPTION
fixes https://github.com/jesseduffield/lazydocker/issues/260

sorts images by name and refreshes images upon receiving an event

Also stops refreshing containers/services after an action because that's no longer necessary given the event-based refreshing that was recently introduced