### PR TITLE
default to no timestamps in logs

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -29,7 +29,7 @@ gui:
   returnImmediately: false
   wrapMainPanel: false
 logs:
-  timestamps: true
+  timestamps: false
   since: '60m'
 commandTemplates:
   dockerCompose: docker-compose
@@ -39,8 +39,7 @@ commandTemplates:
   viewServiceLogs: '{{ .DockerCompose }} logs --follow {{ .Service.Name }}'
   rebuildService: '{{ .DockerCompose }} up -d --build {{ .Service.Name }}'
   recreateService: '{{ .DockerCompose }} up -d --force-recreate {{ .Service.Name }}'
-  viewContainerLogs:
-    docker logs --timestamps --follow --since=60m {{ .Container.ID
+  viewContainerLogs: docker logs --follow --since=60m {{ .Container.ID
     }}
   allLogs: '{{ .DockerCompose }} logs --tail=300 --follow'
   viewAlLogs: '{{ .DockerCompose }} logs'

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -320,7 +320,7 @@ func GetDefaultConfig() UserConfig {
 		},
 		ConfirmOnQuit: false,
 		Logs: LogsConfig{
-			Timestamps: true,
+			Timestamps: false,
 			Since:      "60m",
 		},
 		CommandTemplates: CommandTemplatesConfig{


### PR DESCRIPTION
There's been a couple issues complaining about timestamps in logs. I personally have always had timestamps disabled, and so I'm thinking it's fair enough to change the default, especially because the typical person probably doesn't pass '--timestamps' to the docker logs command.

At any rate it's configurable so you can enable timestamps with:
```yaml
logs:
  timestamps: true
```