### PR TITLE
Include image name on config tab

### DIFF
--- a/pkg/gui/containers_panel.go
+++ b/pkg/gui/containers_panel.go
@@ -145,6 +145,7 @@ func (gui *Gui) renderContainerConfig(container *commands.Container) error {
 	output := ""
 	output += utils.WithPadding("ID: ", padding) + container.ID + "\n"
 	output += utils.WithPadding("Name: ", padding) + container.Name + "\n"
+	output += utils.WithPadding("Image: ", padding) + container.Details.Config.Image + "\n"
 	output += utils.WithPadding("Command: ", padding) + strings.Join(append([]string{container.Details.Path}, container.Details.Args...), " ") + "\n"
 	output += utils.WithPadding("Labels: ", padding) + utils.FormatMap(padding, container.Details.Config.Labels)
 	output += "\n"


### PR DESCRIPTION
Sometimes the container image names can be cut off by long container names, for example in https://github.com/jesseduffield/lazydocker/issues/263.

This PR add the container name on the config tab:

![Screenshot from 2022-06-03 17-13-14](https://user-images.githubusercontent.com/144435/171905924-18341bd1-278b-4fcc-9f36-12e88917e695.png)