### PR TITLE
remove extracted lazydocker binary

### DIFF
--- a/scripts/install_update_linux.sh
+++ b/scripts/install_update_linux.sh
@@ -21,4 +21,4 @@ GITHUB_URL="https://github.com/jesseduffield/lazydocker/releases/download/${GITH
 curl -L -o lazydocker.tar.gz $GITHUB_URL
 tar xzvf lazydocker.tar.gz lazydocker
 install -Dm 755 lazydocker -t "$DIR"
-rm lazydocker.tar.gz
+rm lazydocker lazydocker.tar.gz


### PR DESCRIPTION
The installation method used up until now would always leave one copy of the lazydocker binary in the extraction directory. This copy is not actually needed after installation, so it should be removed. TheAxelander also pointed this out in his comment at https://github.com/jesseduffield/lazydocker/issues/270#issuecomment-1042983635.
This commit changes that behaviour and makes the install script cleanup after itself.