### PR TITLE
Changed "White" colors to "Default" to work in both light and dark terminals

### DIFF
--- a/pkg/gui/confirmation_panel.go
+++ b/pkg/gui/confirmation_panel.go
@@ -147,9 +147,7 @@ func (gui *Gui) setKeyBindings(g *gocui.Gui, handleConfirm, handleClose func(*go
 }
 
 // createSpecificErrorPanel allows you to create an error popup, specifying the
-//
-//	view to be focused when the user closes the popup, and a boolean specifying
-//
+// view to be focused when the user closes the popup, and a boolean specifying
 // whether we will log the error. If the message may include a user password,
 // this function is to be used over the more generic createErrorPanel, with
 // willLog set to false

--- a/pkg/gui/confirmation_panel.go
+++ b/pkg/gui/confirmation_panel.go
@@ -81,7 +81,7 @@ func (gui *Gui) prepareConfirmationPanel(currentView *gocui.View, title, prompt 
 		gui.g.StartTicking()
 		confirmationView.Title = title
 		confirmationView.Wrap = true
-		confirmationView.FgColor = gocui.ColorWhite
+		confirmationView.FgColor = gocui.ColorDefault
 	}
 	gui.g.Update(func(g *gocui.Gui) error {
 		return gui.switchFocus(gui.g, currentView, confirmationView, false)
@@ -147,7 +147,9 @@ func (gui *Gui) setKeyBindings(g *gocui.Gui, handleConfirm, handleClose func(*go
 }
 
 // createSpecificErrorPanel allows you to create an error popup, specifying the
-//  view to be focused when the user closes the popup, and a boolean specifying
+//
+//	view to be focused when the user closes the popup, and a boolean specifying
+//
 // whether we will log the error. If the message may include a user password,
 // this function is to be used over the more generic createErrorPanel, with
 // willLog set to false

--- a/pkg/gui/gocui.go
+++ b/pkg/gui/gocui.go
@@ -32,7 +32,7 @@ func GetGocuiAttribute(key string) gocui.Attribute {
 	if present {
 		return value
 	}
-	return gocui.ColorWhite
+	return gocui.ColorDefault
 }
 
 // GetGocuiStyle bitwise OR's a list of attributes obtained via the given keys

--- a/pkg/gui/menu_panel.go
+++ b/pkg/gui/menu_panel.go
@@ -75,7 +75,7 @@ func (gui *Gui) createMenu(title string, items interface{}, itemCount int, handl
 	x0, y0, x1, y1 := gui.getConfirmationPanelDimensions(gui.g, false, list)
 	menuView, _ := gui.g.SetView("menu", x0, y0, x1, y1, 0)
 	menuView.Title = title
-	menuView.FgColor = gocui.ColorWhite
+	menuView.FgColor = gocui.ColorDefault
 	menuView.Clear()
 	fmt.Fprint(menuView, list)
 	gui.State.Panels.Menu.SelectedLine = 0

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -293,7 +293,7 @@ func GetGocuiAttribute(key string) gocui.Attribute {
 	if present {
 		return value
 	}
-	return gocui.ColorWhite
+	return gocui.ColorDefault
 }
 
 // GetColorAttribute gets the color attribute from the string


### PR DESCRIPTION
I just tried to quickly fix the issue that, in a light terminal, the text in menus is barely legible. See also https://github.com/jesseduffield/lazydocker/issues/214 on that.

I'm using Solarized Light/Dark and automatically switch between them via MacOS Dark Mode, and now with the font color set to "Default" instead of "White", it's easily readable in both modes. Also all the other themes that come with iTerm2 are looking good now.