### PR TITLE
Fix execute shell command to take into account edge cases

### DIFF
--- a/pkg/gui/containers_panel.go
+++ b/pkg/gui/containers_panel.go
@@ -533,7 +533,7 @@ func (gui *Gui) containerExecShell(container *commands.Container) error {
 	})
 
 	// TODO: use SDK
-	resolvedCommand := utils.ApplyTemplate("docker exec -it {{ .Container.ID }} /bin/sh -c 'eval $(grep ^$(id -un): /etc/passwd | cut -d : -f 7-)'", commandObject)
+	resolvedCommand := utils.ApplyTemplate("docker exec -it {{ .Container.ID }} /bin/sh -c 'eval $( (grep ^[^:]*:[^:]*:$(id -u): /etc/passwd || echo \"::::::/bin/sh\") | cut -d : -f 7-) || eval $(echo \"/bin/sh\")'", commandObject)
 	// attach and return the subprocess error
 	cmd := gui.OSCommand.ExecutableFromString(resolvedCommand)
 	return gui.runSubprocess(cmd)


### PR DESCRIPTION
This PR resolves #350 

The new proposed command is

```
/bin/sh -e -c 'eval $( (grep ^[^:]*:[^:]*:$(id -u): /etc/passwd || echo "::::::/bin/sh") | cut -d : -f 7-) || eval $(echo "/bin/sh")'
```

Changes are following:
1. Grep `/etc/passwd` with UID instead of username. `id -un` can start throwing errors if current user does not exist in `/etc/passwd` because it looks into the passwd file to determine user name (switch `-n`). So the first step is to make sure `id` doesn't throw - hence I changed grepping pattern to rely on uid (which comes in the [third field of the file](https://en.wikipedia.org/wiki/Passwd#Password_file)). While this change is not strictly required but it prevents output from error pollution. 

2. `|| echo "::::::/bin/sh` makes sure if grep doesn't find uid in passwd file we will feed a dummy entry to the pipe so lazydocker would start `/bin/sh` at least

3. The last part (`|| eval $(echo "/bin/sh")`) is here to guard against `/bin/false` or `/sbin/nologin` shells that are commonly used to tighten security. If we fail to launch shell specified in the `/etc/passwd` then lazydocker would start `/bin/sh` instead.

1 and 2 address problem with `bitnami/openldap` image mentioned in #350
In this case everything works flawlessly

3 addresses problem with `quay.io/keycloak/keycloak:18.0` image described in the same issue. Here execute shell works but error message that `/sbin/nologin` is not found yet present. I don't think it worth it to suppress the error as the command will become even more complicated

![image](https://user-images.githubusercontent.com/153191/188212407-2000d4e4-797e-45b2-a556-1388e7c94ab4.png)
