### PR TITLE
Allow user to replace docker repo prefix from image names

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -90,3 +90,14 @@ customCommands:
       command: 'docker exec -it {{ .Container.ID }} bash'
       serviceNames: []
 ```
+
+## Replacements
+
+You can add replacements like so:
+
+```yaml
+replacements:
+  imageNamePrefixes:
+    '123456789012.dkr.ecr.us-east-1.amazonaws.com': '<prod>'
+    '923456789999.dkr.ecr.us-east-1.amazonaws.com': '<dev>'
+```

--- a/pkg/commands/image.go
+++ b/pkg/commands/image.go
@@ -123,6 +123,13 @@ func (c *DockerCommand) RefreshImages() ([]*Image, error) {
 		if len(nameParts) > 1 {
 			tag = nameParts[len(nameParts)-1]
 			name = strings.Join(nameParts[:len(nameParts)-1], ":")
+
+			for prefix, replacement := range c.Config.UserConfig.Replacements.ImageNamePrefixes {
+				if strings.HasPrefix(name, prefix) {
+					name = strings.Replace(name, prefix, replacement, 1)
+					break
+				}
+			}
 		}
 
 		ownImages[i] = &Image{

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -58,7 +58,7 @@ type UserConfig struct {
 	// what stat info to graph
 	Stats StatsConfig `yaml:"stats,omitempty"`
 
-	// Replacements determines how we render a container's info
+	// Replacements determines how we render an item's info
 	Replacements Replacements `yaml:"replacements,omitempty"`
 }
 

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -57,6 +57,9 @@ type UserConfig struct {
 	// Stats determines how long lazydocker will gather container stats for, and
 	// what stat info to graph
 	Stats StatsConfig `yaml:"stats,omitempty"`
+
+	// Replacements determines how we render a container's info
+	Replacements Replacements `yaml:"replacements,omitempty"`
 }
 
 // ThemeConfig is for setting the colors of panels and some text.
@@ -258,6 +261,12 @@ type CustomCommands struct {
 	Volumes []CustomCommand `yaml:"volumes,omitempty"`
 }
 
+// Replacements contains the stuff relating to rendering a container's info
+type Replacements struct {
+	// ImageNamePrefixes tells us how to replace a prefix in the Docker image name
+	ImageNamePrefixes map[string]string `yaml:"imageNamePrefixes,omitempty"`
+}
+
 // CustomCommand is a template for a command we want to run against a service or
 // container
 type CustomCommand struct {
@@ -403,6 +412,9 @@ func GetDefaultConfig() UserConfig {
 					Color:    "green",
 				},
 			},
+		},
+		Replacements: Replacements{
+			ImageNamePrefixes: map[string]string{},
 		},
 	}
 }


### PR DESCRIPTION
Example usage:

```yaml
replacements:
  imageNamePrefixes:
    '123456789012.dkr.ecr.us-east-1.amazonaws.com': '<prod>'
    '923456789999.dkr.ecr.us-east-1.amazonaws.com': '<dev>'
```

Closes #316