### PR TITLE
sort volumes first on whether they have labels and secondly on name

### DIFF
--- a/pkg/commands/volume.go
+++ b/pkg/commands/volume.go
@@ -36,7 +36,16 @@ func (c *DockerCommand) RefreshVolumes() error {
 
 	ownVolumes := make([]*Volume, len(volumes))
 
+	// we're sorting these volumes based on whether they have labels defined,
+	// because those are the ones you typically care about.
+	// Within that, we also sort them alphabetically
 	sort.Slice(volumes, func(i, j int) bool {
+		if len(volumes[i].Labels) == 0 && len(volumes[j].Labels) > 0 {
+			return false
+		}
+		if len(volumes[i].Labels) > 0 && len(volumes[j].Labels) == 0 {
+			return true
+		}
 		return volumes[i].Name < volumes[j].Name
 	})
 


### PR DESCRIPTION
I've been seeing a bunch of random volumes with long hashes as names, with no labels. I typically want to interact with the volumes that have human-readable names, and these typically have labels, so I'm sorting by that first.