### PR TITLE
ignore items with configured substrings

### DIFF
--- a/pkg/commands/image.go
+++ b/pkg/commands/image.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types/image"
+	"github.com/samber/lo"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -143,6 +144,12 @@ func (c *DockerCommand) RefreshImages() ([]*Image, error) {
 			DockerCommand: c,
 		}
 	}
+
+	ownImages = lo.Filter(ownImages, func(image *Image, _ int) bool {
+		return !lo.SomeBy(c.Config.UserConfig.Ignore, func(ignore string) bool {
+			return strings.Contains(image.Name, ignore)
+		})
+	})
 
 	noneLabel := "<none>"
 

--- a/pkg/commands/volume.go
+++ b/pkg/commands/volume.go
@@ -3,10 +3,12 @@ package commands
 import (
 	"context"
 	"sort"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 )
 
@@ -59,6 +61,12 @@ func (c *DockerCommand) RefreshVolumes() error {
 			DockerCommand: c,
 		}
 	}
+
+	ownVolumes = lo.Filter(ownVolumes, func(volume *Volume, _ int) bool {
+		return !lo.SomeBy(c.Config.UserConfig.Ignore, func(ignore string) bool {
+			return strings.Contains(volume.Name, ignore)
+		})
+	})
 
 	c.Volumes = ownVolumes
 

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -60,6 +60,11 @@ type UserConfig struct {
 
 	// Replacements determines how we render an item's info
 	Replacements Replacements `yaml:"replacements,omitempty"`
+
+	// For demo purposes: any list item with one of these strings as a substring
+	// will be filtered out and not displayed.
+	// Not documented because it's subject to change
+	Ignore []string `yaml:"ignore,omitempty"`
 }
 
 // ThemeConfig is for setting the colors of panels and some text.


### PR DESCRIPTION
I'm demoing lazydocker for hacktoberfest tomorrow and want to be able to easily filter out anything in my local docker environment that's confidential, by providing a list of substrings of item names that I don't want to appear in my list panels.