### PR TITLE
Wrap custom commands on shell

### DIFF
--- a/pkg/commands/os_default_platform.go
+++ b/pkg/commands/os_default_platform.go
@@ -9,12 +9,10 @@ import (
 
 func getPlatform() *Platform {
 	return &Platform{
-		os:                   runtime.GOOS,
-		shell:                "bash",
-		shellArg:             "-c",
-		escapedQuote:         "'",
-		openCommand:          "open {{filename}}",
-		openLinkCommand:      "open {{link}}",
-		fallbackEscapedQuote: "\"",
+		os:              runtime.GOOS,
+		shell:           "bash",
+		shellArg:        "-c",
+		openCommand:     "open {{filename}}",
+		openLinkCommand: "open {{link}}",
 	}
 }

--- a/pkg/commands/os_windows.go
+++ b/pkg/commands/os_windows.go
@@ -2,10 +2,8 @@ package commands
 
 func getPlatform() *Platform {
 	return &Platform{
-		os:                   "windows",
-		shell:                "cmd",
-		shellArg:             "/c",
-		escapedQuote:         `\"`,
-		fallbackEscapedQuote: "\\'",
+		os:       "windows",
+		shell:    "cmd",
+		shellArg: "/c",
 	}
 }

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -306,6 +306,10 @@ type CustomCommand struct {
 	// option where the output plays in the main panel.
 	Attach bool `yaml:"attach"`
 
+	// Shell indicates whether to invoke the Command on a shell or not.
+	// Example of a bash invoked command: `/bin/bash -c "{Command}".
+	Shell bool `yaml:"shell"`
+
 	// Command is the command we want to run. We can use the go templates here as
 	// well. One example might be `{{ .DockerCompose }} exec {{ .Service.Name }}
 	// /bin/sh`

--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -18,10 +18,14 @@ func (gui *Gui) createCommandMenu(customCommands []config.CustomCommand, command
 				return command.InternalFunction()
 			}
 
+			resolvedCommand := command.Command
+			if command.Shell {
+				resolvedCommand = gui.OSCommand.NewCommandStringWithShell(command.Command)
+			}
+
 			// if we have a command for attaching, we attach and return the subprocess error
 			if command.Attach {
-				cmd := gui.OSCommand.ExecutableFromString(resolvedCommand)
-				return gui.runSubprocess(cmd)
+				return gui.runSubprocess(gui.OSCommand.ExecutableFromString(resolvedCommand))
 			}
 
 			return gui.WithWaitingStatus(waitingStatus, func() error {


### PR DESCRIPTION
## Context
This solves https://github.com/jesseduffield/lazydocker/issues/354

## Implementation
Ideally, we'd re-use `ICmdObjBuilder` from `lazygit` across both projects, but that'd require a complete refactor here. So i ported the string replacement for Windows OS and the wrapping of new shell. 