### PR TITLE
use service name as service ID

### DIFF
--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -244,22 +244,21 @@ func (c *DockerCommand) GetServices() ([]*Service, error) {
 	}
 
 	composeCommand := c.Config.UserConfig.CommandTemplates.DockerCompose
-	output, err := c.OSCommand.RunCommandWithOutput(fmt.Sprintf("%s config --hash=*", composeCommand))
+	output, err := c.OSCommand.RunCommandWithOutput(fmt.Sprintf("%s config --services", composeCommand))
 	if err != nil {
 		return nil, err
 	}
 
 	// output looks like:
-	// service1 998d6d286b0499e0ff23d66302e720991a2asdkf9c30d0542034f610daf8a971
-	// service2 asdld98asdklasd9bccd02438de0994f8e19cbe691feb3755336ec5ca2c55971
+	// service1
+	// service2
 
 	lines := utils.SplitLines(output)
 	services := make([]*Service, len(lines))
 	for i, str := range lines {
-		arr := strings.Split(str, " ")
 		services[i] = &Service{
-			Name:          arr[0],
-			ID:            arr[1],
+			Name:          str,
+			ID:            str,
 			OSCommand:     c.OSCommand,
 			Log:           c.Log,
 			DockerCommand: c,


### PR DESCRIPTION
Resolves https://github.com/jesseduffield/lazydocker/issues/402

## test
run the built lazydocker binary with the following `docker-compose.yml` file, and confirmed that the selected service does not move.

```
version: "3.9"
services:
  service-a:
    image: "nginx:latest"
  service-b:
    image: "nginx:latest"
  service-c:
    image: "nginx:latest"
```

https://user-images.githubusercontent.com/6212292/203588199-514d63ed-89c1-4de9-ac37-bbf5cfecd82e.mov

