### PR TITLE
Short status

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -38,6 +38,10 @@ gui:
   expandFocusedSidePanel: false
   # Determines which screen mode will be used on startup
   screenMode: "normal" # one of 'normal' | 'half' | 'fullscreen'
+  # Determines the style of the container status and container health display in the
+  # containers panel. "long": full words (default), "short": one or two characters,
+  # "icon": unicode emoji.
+  containerStatusHealthStyle: "long"
 logs:
   timestamps: false
   since: '60m' # set to '' to show all logs

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -133,6 +133,11 @@ type GuiConfig struct {
 
 	// ScreenMode allow user to specify which screen mode will be used on startup
 	ScreenMode string `yaml:"screenMode,omitempty"`
+
+	// Determines the style of the container status and container health display in the
+	// containers panel. "long": full words (default), "short": one or two characters,
+	// "icon": unicode emoji.
+	ContainerStatusHealthStyle string `yaml:"containerStatusHealthStyle"`
 }
 
 // CommandTemplatesConfig determines what commands actually get called when we
@@ -358,14 +363,15 @@ func GetDefaultConfig() UserConfig {
 				InactiveBorderColor: []string{"default"},
 				OptionsTextColor:    []string{"blue"},
 			},
-			ShowAllContainers:      false,
-			ReturnImmediately:      false,
-			WrapMainPanel:          true,
-			LegacySortContainers:   false,
-			SidePanelWidth:         0.3333,
-			ShowBottomLine:         true,
-			ExpandFocusedSidePanel: false,
-			ScreenMode:             "normal",
+			ShowAllContainers:          false,
+			ReturnImmediately:          false,
+			WrapMainPanel:              true,
+			LegacySortContainers:       false,
+			SidePanelWidth:             0.3333,
+			ShowBottomLine:             true,
+			ExpandFocusedSidePanel:     false,
+			ScreenMode:                 "normal",
+			ContainerStatusHealthStyle: "long",
 		},
 		ConfirmOnQuit: false,
 		Logs: LogsConfig{

--- a/pkg/gui/containers_panel.go
+++ b/pkg/gui/containers_panel.go
@@ -96,7 +96,9 @@ func (gui *Gui) getContainersPanel() *panels.SideListPanel[*commands.Container] 
 
 			return true
 		},
-		GetTableCells: presentation.GetContainerDisplayStrings,
+		GetTableCells: func(container *commands.Container) []string {
+			return presentation.GetContainerDisplayStrings(&gui.Config.UserConfig.Gui, container)
+		},
 	}
 }
 

--- a/pkg/gui/presentation/services.go
+++ b/pkg/gui/presentation/services.go
@@ -3,13 +3,26 @@ package presentation
 import (
 	"github.com/fatih/color"
 	"github.com/jesseduffield/lazydocker/pkg/commands"
+	"github.com/jesseduffield/lazydocker/pkg/config"
 	"github.com/jesseduffield/lazydocker/pkg/utils"
 )
 
-func GetServiceDisplayStrings(service *commands.Service) []string {
+func GetServiceDisplayStrings(guiConfig *config.GuiConfig, service *commands.Service) []string {
 	if service.Container == nil {
+		var containerState string
+		switch guiConfig.ContainerStatusHealthStyle {
+		case "short":
+			containerState = "n"
+		case "icon":
+			containerState = "."
+		case "long":
+			fallthrough
+		default:
+			containerState = "none"
+		}
+
 		return []string{
-			utils.ColoredString("none", color.FgBlue),
+			utils.ColoredString(containerState, color.FgBlue),
 			"",
 			service.Name,
 			"",
@@ -20,8 +33,8 @@ func GetServiceDisplayStrings(service *commands.Service) []string {
 
 	container := service.Container
 	return []string{
-		getContainerDisplayStatus(container),
-		getContainerDisplaySubstatus(container),
+		getContainerDisplayStatus(guiConfig, container),
+		getContainerDisplaySubstatus(guiConfig, container),
 		service.Name,
 		getDisplayCPUPerc(container),
 		utils.ColoredString(displayPorts(container), color.FgYellow),

--- a/pkg/gui/services_panel.go
+++ b/pkg/gui/services_panel.go
@@ -74,7 +74,9 @@ func (gui *Gui) getServicesPanel() *panels.SideListPanel[*commands.Service] {
 
 			return a.Name < b.Name
 		},
-		GetTableCells: presentation.GetServiceDisplayStrings,
+		GetTableCells: func(service *commands.Service) []string {
+			return presentation.GetServiceDisplayStrings(&gui.Config.UserConfig.Gui, service)
+		},
 		Hide: func() bool {
 			return !gui.DockerCommand.InDockerComposeProject
 		},


### PR DESCRIPTION
- Add ability to use a 'short' or 'icon' set for showing container status.
- Some additional refactoring of util functions to make what the variables are more clear and improve (not fix, go-runewidth isn't bulletproof) support for emoji and unicode text symbols in tables. (This can be rolled back if people aren't on-board).
- Added config to allow it to be set from 'long' (default), 'short' and 'icon'.
- Added to the Config.md to show it can be configured.