### PR TITLE
Docs: explain go templates in custom commands

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -104,6 +104,8 @@ customCommands:
       serviceNames: []
 ```
 
+For a full list of template variables that are available (such as `{{ .Container.ID }}`), see the fields of our [Container struct](https://github.com/jesseduffield/lazydocker/blob/17fcdb2b202c18b340737c31ae5429fe0c1478a8/pkg/commands/container.go#L23-L43). For example, to write a command that uses a container's image ID, you can use `{{ .Container.Container.ImageID }}`.
+
 ## Replacements
 
 You can add replacements like so:

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -31,7 +31,7 @@ gui:
   # Side panel width as a ratio of the screen's width
   sidePanelWidth: 0.333
   # Determines whether we show the bottom line (the one containing keybinding
-	# info and the status of the app).
+  # info and the status of the app).
   showBottomLine: true
   # When true, increases vertical space used by focused side panel,
   # creating an accordion effect

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -104,7 +104,10 @@ customCommands:
       serviceNames: []
 ```
 
-For a full list of template variables that are available (such as `{{ .Container.ID }}`), see the fields of our [Container struct](https://pkg.go.dev/github.com/jesseduffield/lazydocker@v0.20.0/pkg/commands#Container). For example, to write a command that uses a container's image ID, you can use `{{ .Container.Container.ImageID }}`.
+You may use the following go templates (such as `{{ .Container.ID }}` above) in your commands:
+- `{{ .DockerCompose }}`: the docker compose command (default: `docker-compose`)
+- [`{{ .Container }}`](https://pkg.go.dev/github.com/jesseduffield/lazydocker@v0.20.0/pkg/commands#Container) and its fields. For example: `{{ .Container.Container.ImageID }}`
+- [`{{ .Service }}`](https://pkg.go.dev/github.com/jesseduffield/lazydocker@v0.20.0/pkg/commands#Service) and its fields. For example: `{{ .Service.Name }}`
 
 ## Replacements
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -104,7 +104,7 @@ customCommands:
       serviceNames: []
 ```
 
-For a full list of template variables that are available (such as `{{ .Container.ID }}`), see the fields of our [Container struct](https://github.com/jesseduffield/lazydocker/blob/17fcdb2b202c18b340737c31ae5429fe0c1478a8/pkg/commands/container.go#L23-L43). For example, to write a command that uses a container's image ID, you can use `{{ .Container.Container.ImageID }}`.
+For a full list of template variables that are available (such as `{{ .Container.ID }}`), see the fields of our [Container struct](https://pkg.go.dev/github.com/jesseduffield/lazydocker@v0.20.0/pkg/commands#Container). For example, to write a command that uses a container's image ID, you can use `{{ .Container.Container.ImageID }}`.
 
 ## Replacements
 


### PR DESCRIPTION
This PR edits the `Config.md` doc to explain the go template variables that are available to authors of custom commands.

With this info documented, it becomes much easier for users to write commands such as:
```yml
customCommands:
  containers:
    -
      name: dive
      attach: true
      command: dive {{ .Container.Container.ImageID }}
      serviceNames: []
```

This also takes care of a minor yaml issue in the doc. Before the change, Github highlighted this as invalid:
<img alt="image" src="https://user-images.githubusercontent.com/39979644/215167897-c4b14dc6-335d-4bf1-8dbe-3371e05a8dfa.png">
