### PR TITLE
Re-enable custom command template application

### DIFF
--- a/pkg/gui/custom_commands.go
+++ b/pkg/gui/custom_commands.go
@@ -18,9 +18,8 @@ func (gui *Gui) createCommandMenu(customCommands []config.CustomCommand, command
 				return command.InternalFunction()
 			}
 
-			resolvedCommand := command.Command
 			if command.Shell {
-				resolvedCommand = gui.OSCommand.NewCommandStringWithShell(command.Command)
+				resolvedCommand = gui.OSCommand.NewCommandStringWithShell(resolvedCommand)
 			}
 
 			// if we have a command for attaching, we attach and return the subprocess error


### PR DESCRIPTION
A regression was introduced in #387 where the template resolution in custom commands was dropped entirely.

This should close both #449 and #468.