### PR TITLE
Gracefully check for docker config

### DIFF
--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -338,11 +338,7 @@ func determineDockerHost() (string, error) {
 
 	currentContext := os.Getenv("DOCKER_CONTEXT")
 	if currentContext == "" {
-		dockerConfigDir := cliconfig.Dir()
-		if _, err := os.Stat(dockerConfigDir); err != nil {
-			return "", err
-		}
-		cf, err := cliconfig.Load(dockerConfigDir)
+		cf, err := cliconfig.Load(cliconfig.Dir())
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
It's fine if the file doesn't exist

Fixes https://github.com/jesseduffield/lazydocker/issues/488