### PR TITLE
feat: add volume `CreatedAt` field to volumes Config side panel

### DIFF
--- a/pkg/commands/volume.go
+++ b/pkg/commands/volume.go
@@ -17,6 +17,7 @@ type Volume struct {
 	OSCommand     *OSCommand
 	Log           *logrus.Entry
 	DockerCommand LimitedDockerCommand
+	CreatedAt     string
 }
 
 // RefreshVolumes gets the volumes and stores them
@@ -38,6 +39,7 @@ func (c *DockerCommand) RefreshVolumes() ([]*Volume, error) {
 			OSCommand:     c.OSCommand,
 			Log:           c.Log,
 			DockerCommand: c,
+			CreatedAt:     volume.CreatedAt,
 		}
 	}
 

--- a/pkg/gui/volumes_panel.go
+++ b/pkg/gui/volumes_panel.go
@@ -66,6 +66,7 @@ func (gui *Gui) volumeConfigStr(volume *commands.Volume) string {
 	output += utils.WithPadding("Mountpoint: ", padding) + volume.Volume.Mountpoint + "\n"
 	output += utils.WithPadding("Labels: ", padding) + utils.FormatMap(padding, volume.Volume.Labels) + "\n"
 	output += utils.WithPadding("Options: ", padding) + utils.FormatMap(padding, volume.Volume.Options) + "\n"
+	output += utils.WithPadding("CreatedAt: ", padding) + volume.Volume.CreatedAt + "\n"
 
 	output += utils.WithPadding("Status: ", padding)
 	if volume.Volume.Status != nil {


### PR DESCRIPTION
This MR adds the `CreatedAt` value associated with a Docker volume to the volumes Config side panel. Here is an example of how the value looks, and how it matches the output of `docker volume inspect <volume>`.

```
$ docker volume inspect vscode
[
    {
        "CreatedAt": "2022-11-07T21:06:17Z",
        "Driver": "local",
        "Labels": {},
        "Mountpoint": "/var/lib/docker/volumes/vscode/_data",
        "Name": "vscode",
        "Options": {},
        "Scope": "local"
    }
]
```

<img width="415" alt="image" src="https://github.com/jesseduffield/lazydocker/assets/17325936/3e81e3ed-afe5-49b1-8a18-12f80119ec6c">
