### PR TITLE
Fix install with unsupported tar -z

### DIFF
--- a/scripts/install_update_linux.sh
+++ b/scripts/install_update_linux.sh
@@ -19,6 +19,7 @@ GITHUB_URL="https://github.com/jesseduffield/lazydocker/releases/download/${GITH
 
 # install/update the local binary
 curl -L -o lazydocker.tar.gz $GITHUB_URL
-tar xzvf lazydocker.tar.gz lazydocker
+#tar xzvf lazydocker.tar.gz lazydocker
+gzip -dc lazydocker.tar.gz | tar xf - lazydocker
 install -Dm 755 lazydocker -t "$DIR"
 rm lazydocker lazydocker.tar.gz


### PR DESCRIPTION
Some tar binaries (like the one from busybox in buildroot) have troubles with "tar -z" parameters. This patch overcomes the problem calling to gzip prior to tar.