### PR TITLE
Fix small Portuguese typo

### DIFF
--- a/pkg/i18n/portuguese.go
+++ b/pkg/i18n/portuguese.go
@@ -121,7 +121,7 @@ func portugueseSet() TranslationSet {
 		ConfirmStopContainers:       "Tem certeza que deseja parar todos os contêineres?",
 		ConfirmRemoveContainers:     "Tem certeza que deseja remover todos os contêineres?",
 		ConfirmPruneVolumes:         "Tem certeza que deseja destruir todos os volumes não utilizados?",
-		ConfirmPruneNetworks:        "Tem certeza que deseja destruir todos as redes não utilizadas?",
+		ConfirmPruneNetworks:        "Tem certeza que deseja destruir todas as redes não utilizadas?",
 		StopService:                 "Tem certeza que deseja parar os contêineres deste serviço?",
 		StopContainer:               "Tem certeza que deseja parar este contêiner?",
 		PressEnterToReturn:          "Pressione enter para retornar ao lazydocker (este prompt pode ser desativado em sua configuração definindo `gui.returnImmediately: true`)",


### PR DESCRIPTION
This Pull Request corrects a word gender typo in Portuguese i18n.

![Screenshot from 2024-01-23 17-39-27](https://github.com/jesseduffield/lazydocker/assets/41298947/2918eb3b-6081-4d1d-aadc-91fc65c92dce)

In "todos as redes" and any Portuguese context, the substantive "redes" (network) represent a feminine Portuguese word  and an article or other word that precedes and refers to it must also be feminine. The word "todos" (all) is a masculine word and should be "todas" (female) to follow the article "as" and match the gender in the context.

For a more detailed grammar explanation, check this article: https://www.practiceportuguese.com/learning-notes/the-gender-of-portuguese-words