### PR TITLE
Fix Go Version to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The script installs downloaded binary to `$HOME/.local/bin` directory by default
 
 ### Go
 
-Required Go Version >= **1.16**
+Required Go Version >= **1.19**
 
 ```sh
 go install github.com/jesseduffield/lazydocker@latest


### PR DESCRIPTION
I tried to install using version: `go version go1.18.1 linux/amd64` and received the following error:

```bash
go install github.com/jesseduffield/lazydocker@latest
go: downloading github.com/jesseduffield/lazydocker v0.23.1
go: downloading github.com/docker/docker v20.10.27-0.20230918140811-29a0e76e6495+incompatible
go: downloading github.com/go-errors/errors v1.4.2
go: downloading github.com/jesseduffield/yaml v0.0.0-20190702115811-b900b7e08b56
go: downloading github.com/integrii/flaggy v1.4.0
go: downloading github.com/samber/lo v1.31.0
go: downloading github.com/fatih/color v1.10.0
go: downloading github.com/goccy/go-yaml v1.11.0
go: downloading github.com/jesseduffield/gocui v0.3.1-0.20221023185936-ef06450f4fdc
go: downloading github.com/mattn/go-runewidth v0.0.14
go: downloading github.com/sirupsen/logrus v1.4.2
go: downloading github.com/OpenPeeDeeP/xdg v0.2.1-0.20190312153938-4ba9e1eb294c
go: downloading github.com/mattn/go-colorable v0.1.8
go: downloading github.com/mattn/go-isatty v0.0.12
go: downloading golang.org/x/exp v0.0.0-20220428152302-39d4317da171
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
go: downloading github.com/docker/cli v20.10.15+incompatible
go: downloading github.com/imdario/mergo v0.3.8
go: downloading github.com/jesseduffield/kill v0.0.0-20220618033138-bfbe04675d10
go: downloading github.com/mgutz/str v1.2.0
go: downloading github.com/sasha-s/go-deadlock v0.3.1
go: downloading github.com/boz/go-throttle v0.0.0-20160922054636-fdc4eab740c1
go: downloading github.com/gookit/color v1.5.0
go: downloading github.com/jesseduffield/lazycore v0.0.0-20221023210126-718a4caea996
go: downloading github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad
go: downloading github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21
go: downloading github.com/docker/distribution v2.8.2+incompatible
go: downloading github.com/docker/go-connections v0.4.0
go: downloading github.com/opencontainers/go-digest v1.0.0-rc1
go: downloading github.com/opencontainers/image-spec v1.0.2
go: downloading github.com/gdamore/tcell/v2 v2.5.3
go: downloading github.com/docker/go-units v0.4.0
go: downloading github.com/jesseduffield/asciigraph v0.0.0-20190605104717-6d88e39309ee
go: downloading github.com/mcuadros/go-lookup v0.0.0-20171110082742-5650f26be767
go: downloading github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5
go: downloading github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778
go: downloading github.com/fvbommel/sortorder v1.1.0
go: downloading github.com/docker/docker-credential-helpers v0.8.0
go: downloading github.com/gdamore/encoding v1.0.0
go: downloading golang.org/x/text v0.13.0
# github.com/docker/docker-credential-helpers/client
../../go/pkg/mod/github.com/docker/docker-credential-helpers@v0.8.0/client/command.go:34:39: programCmd.Environ undefined (type *exec.Cmd has no field or method Environ)
note: module requires Go 1.19
```
