### PR TITLE
feat: add 'border' option in config

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -33,6 +33,7 @@ to the top of your config file or via [Visual Studio Code settings.json config][
 gui:
   scrollHeight: 2
   language: 'auto' # one of 'auto' | 'en' | 'pl' | 'nl' | 'de' | 'tr'
+  border: 'single' # one of 'single' | 'rounded' | 'double' | 'hidden'
   theme:
     activeBorderColor:
       - green

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -138,6 +138,10 @@ type GuiConfig struct {
 	// containers panel. "long": full words (default), "short": one or two characters,
 	// "icon": unicode emoji.
 	ContainerStatusHealthStyle string `yaml:"containerStatusHealthStyle"`
+
+	// Window border style.
+	// One of 'single' (default) | 'rounded' | 'double' | 'hidden'
+	Border string `yaml:"border"`
 }
 
 // CommandTemplatesConfig determines what commands actually get called when we

--- a/pkg/gui/views.go
+++ b/pkg/gui/views.go
@@ -92,12 +92,23 @@ func (gui *Gui) orderedViewNameMappings() []viewNameMapping {
 }
 
 func (gui *Gui) createAllViews() error {
+	frameRunes := []rune{'─', '│', '┌', '┐', '└', '┘'}
+	switch gui.Config.UserConfig.Gui.Border {
+	case "double":
+		frameRunes = []rune{'═', '║', '╔', '╗', '╚', '╝'}
+	case "rounded":
+		frameRunes = []rune{'─', '│', '╭', '╮', '╰', '╯'}
+	case "hidden":
+		frameRunes = []rune{' ', ' ', ' ', ' ', ' ', ' '}
+	}
+
 	var err error
 	for _, mapping := range gui.orderedViewNameMappings() {
 		*mapping.viewPtr, err = gui.prepareView(mapping.name)
 		if err != nil && err.Error() != UNKNOWN_VIEW_ERROR_MSG {
 			return err
 		}
+		(*mapping.viewPtr).FrameRunes = frameRunes
 		(*mapping.viewPtr).FgColor = gocui.ColorDefault
 	}
 


### PR DESCRIPTION
This PR fixes #516 
A like-for-like implementation of Lazygit's "border" option that allows users to override the border style of Lazydocker's views. 

**Single (default):**
![image](https://github.com/jesseduffield/lazydocker/assets/39483124/267bdaf6-3846-4798-8081-b5202315f26b)

**Rounded:**
![image](https://github.com/jesseduffield/lazydocker/assets/39483124/05a75e76-91ed-4fb6-b02f-76a0e303259d)

**Double:**
![image](https://github.com/jesseduffield/lazydocker/assets/39483124/6db7eaf5-7d4f-4b57-aed9-7706fd7c4e83)

**Hidden:**
![image](https://github.com/jesseduffield/lazydocker/assets/39483124/a626f02d-fbf2-45fa-8a47-45a1bd1c6fae)


