### PR TITLE
Fix buggy log rendering

### DIFF
--- a/pkg/commands/container.go
+++ b/pkg/commands/container.go
@@ -140,7 +140,9 @@ func (c *Container) RenderTop(ctx context.Context) (string, error) {
 	return utils.RenderTable(append([][]string{result.Titles}, result.Processes...))
 }
 
-// DetailsLoaded tells us whether we have yet loaded the details for a container. Because this is an asynchronous operation, sometimes we have the container before we have its details.
+// DetailsLoaded tells us whether we have yet loaded the details for a container.
+// Sometimes it takes some time for a container to have its details loaded
+// after it starts.
 func (c *Container) DetailsLoaded() bool {
 	return c.Details.ContainerJSONBase != nil
 }

--- a/pkg/gui/container_logs.go
+++ b/pkg/gui/container_logs.go
@@ -114,8 +114,10 @@ func (gui *Gui) writeContainerLogs(container *commands.Container, ctx context.Co
 		Follow:     true,
 	})
 	if err != nil {
+		gui.Log.Error(err)
 		return err
 	}
+	defer readCloser.Close()
 
 	if container.DetailsLoaded() && container.Details.Config.Tty {
 		_, err = io.Copy(writer, readCloser)

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -176,11 +176,9 @@ func (gui *Gui) goEvery(interval time.Duration, function func() error) {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for range ticker.C {
-			if gui.PauseBackgroundThreads {
-				return
+			if !gui.PauseBackgroundThreads {
+				_ = function()
 			}
-
-			_ = function()
 		}
 	}()
 }

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -294,7 +294,7 @@ func (gui *Gui) setPanels() {
 }
 
 func (gui *Gui) updateContainerDetails() error {
-	return gui.DockerCommand.UpdateContainerDetails(gui.Panels.Containers.List.GetAllItems())
+	return gui.DockerCommand.RefreshContainerDetails(gui.Panels.Containers.List.GetAllItems())
 }
 
 func (gui *Gui) refresh() {

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -65,9 +65,12 @@ func (t *TaskManager) NewTask(f func(ctx context.Context)) error {
 
 		t.waitingMutex.Lock()
 		defer t.waitingMutex.Unlock()
+		t.taskIDMutex.Lock()
 		if taskID < t.newTaskId {
+			t.taskIDMutex.Unlock()
 			return
 		}
+		t.taskIDMutex.Unlock()
 
 		ctx, cancel := context.WithCancel(context.Background())
 		notifyStopped := make(chan struct{})


### PR DESCRIPTION
Two problems this PR solves:

## 1. Blank logs

Previously we would only load container details a second after we loaded the containers themselves, and we need those container details loaded to know whether a container uses a TTY or not. There are two separate methods you need to use when streaming container logs depending on whether it uses a TTY or not, and we were defaulting to assuming no TTY if the container details were not loaded. If this assumption was wrong, the streaming function would return an error and we would not retry so the logs view would just remain black until the user navigated away from the container and them came back.

Now we load the container details within the method that loads the containers themselves so we can expect them to be present. Interestingly enough, it seems that sometimes docker will return us empty details sometimes so to defend against that, I've also got a check on whether details are loaded, which loops until we get the details or the task is cancelled.

## 2. Lack of screen updates after returning from subprocess

After returning from a subprocess, the screen would only update occasionally: triggered by a docker event. That was because the background task which refreshes the screen every 30ms was killed entirely upon switching to the subprocess, and never recreated. Now we just pause it while the subprocess is still open.