### PR TITLE
change stop to be start stop

### DIFF
--- a/pkg/commands/container.go
+++ b/pkg/commands/container.go
@@ -59,6 +59,12 @@ func (c *Container) Remove(options dockerTypes.ContainerRemoveOptions) error {
 	return nil
 }
 
+// Start starts the container
+func (c *Container) Start() error {
+	c.Log.Warn(fmt.Sprintf("starting container %s", c.Name))
+	return c.Client.ContainerStart(context.Background(), c.ID, dockerTypes.ContainerStartOptions{})
+}
+
 // Stop stops the container
 func (c *Container) Stop() error {
 	c.Log.Warn(fmt.Sprintf("stopping container %s", c.Name))

--- a/pkg/gui/containers_panel.go
+++ b/pkg/gui/containers_panel.go
@@ -342,6 +342,8 @@ func (gui *Gui) handleContainersRemoveMenu(g *gocui.Gui, v *gocui.View) error {
 	})
 }
 
+// TODO: do same thing for start
+// Fix UI not showing it being paused (it should say unpaused)
 func (gui *Gui) PauseContainer(container *commands.Container) error {
 	return gui.WithWaitingStatus(gui.Tr.PausingStatus, func() (err error) {
 		if container.Details.State.Paused {
@@ -367,10 +369,20 @@ func (gui *Gui) handleContainerPause(g *gocui.Gui, v *gocui.View) error {
 	return gui.PauseContainer(container)
 }
 
-func (gui *Gui) handleContainerStop(g *gocui.Gui, v *gocui.View) error {
+func (gui *Gui) handleContainerStartStop(g *gocui.Gui, v *gocui.View) error {
 	container, err := gui.Panels.Containers.GetSelectedItem()
 	if err != nil {
 		return nil
+	}
+
+	if !(container.Container.State == "exited" || container.Container.State == "running") {
+		return gui.createErrorPanel(gui.Tr.CannotStartStop)
+	}
+
+	if container.Container.State == "exited" {
+		return gui.WithWaitingStatus(gui.Tr.StoppingStatus, func() error {
+			return container.Start()
+		})
 	}
 
 	return gui.createConfirmationPanel(gui.Tr.Confirm, gui.Tr.StopContainer, func(g *gocui.Gui, v *gocui.View) error {

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -210,8 +210,8 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			ViewName:    "containers",
 			Key:         's',
 			Modifier:    gocui.ModNone,
-			Handler:     gui.handleContainerStop,
-			Description: gui.Tr.Stop,
+			Handler:     gui.handleContainerStartStop,
+			Description: gui.Tr.StartStop,
 		},
 		{
 			ViewName:    "containers",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -26,6 +26,7 @@ type TranslationSet struct {
 	CannotAttachStoppedContainerError          string
 	CannotAccessDockerSocketError              string
 	CannotKillChildError                       string
+	CannotStartStop                            string
 
 	Donate                      string
 	Cancel                      string
@@ -59,6 +60,7 @@ type TranslationSet struct {
 	Down                        string
 	DownWithVolumes             string
 	Start                       string
+	StartStop                   string
 	Rebuild                     string
 	Recreate                    string
 	PreviousContext             string
@@ -153,6 +155,7 @@ func englishSet() TranslationSet {
 		CannotAttachStoppedContainerError: "You cannot attach to a stopped container, you need to start it first (which you can actually do with the 'r' key) (yes I'm too lazy to do this automatically for you) (pretty cool that I get to communicate one-on-one with you in the form of an error message though)",
 		CannotAccessDockerSocketError:     "Can't access docker socket at: unix:///var/run/docker.sock\nRun lazydocker as root or read https://docs.docker.com/install/linux/linux-postinstall/",
 		CannotKillChildError:              "Waited three seconds for child process to stop. There may be an orphan process that continues to run on your system.",
+		CannotStartStop:                   "Cannot start stop this container",
 
 		Donate:  "Donate",
 		Confirm: "Confirm",
@@ -182,6 +185,7 @@ func englishSet() TranslationSet {
 		Down:                        "down project",
 		DownWithVolumes:             "down project with volumes",
 		Start:                       "start",
+		StartStop:                   "start/stop",
 		Rebuild:                     "rebuild",
 		Recreate:                    "recreate",
 		PreviousContext:             "previous tab",


### PR DESCRIPTION
Fixes #545 

`stop container` now works as a start/stop button