### PR TITLE
Add hint to what .DockerCompose is in documentation

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -65,7 +65,7 @@ logs:
   since: '60m' # set to '' to show all logs
   tail: '' # set to 200 to show last 200 lines of logs
 commandTemplates:
-  dockerCompose: docker-compose
+  dockerCompose: docker-compose # Determines the Docker Compose command to run, referred to as .DockerCompose in commandTemplates
   restartService: '{{ .DockerCompose }} restart {{ .Service.Name }}'
   up:  '{{ .DockerCompose }} up -d'
   down: '{{ .DockerCompose }} down'


### PR DESCRIPTION
It took me a fair bit of time before i understood that '{{ .DockerCompose }}' was defined by the dockerCompose var in commandTemplates.

In hindsight it is VERY obvious.. so i just wanted to contribute a comment that would have been useful to me when i first tried to set this up.