### PR TITLE
Update Config.md: location of the config in windows

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -10,7 +10,7 @@ Changes to the user config will only take place after closing and re-opening laz
 
 - OSX: `~/Library/Application Support/jesseduffield/lazydocker/config.yml`
 - Linux: `~/.config/lazydocker/config.yml`
-- Windows: `C:\\Users\\<User>\\AppData\\Roaming\\jesseduffield\\lazydocker\\config.yml` (I think)
+- Windows: `C:\Users\<User>\AppData\Roaming\lazydocker\config.yml`
 
 JSON schema is available for `config.yml` so that IntelliSense in Visual Studio Code
 (completion and error checking) is automatically enabled when the [YAML Red Hat][yaml]


### PR DESCRIPTION
Tiny change, and my very first contribution to an open source project.

This change just corrects the location of the config file in Windows by removing the author's username from the path.

![image](https://github.com/user-attachments/assets/e5d418d0-7194-4562-9ea6-42b9c0895b23)
