### PR TITLE
Add Flox to installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,13 @@ If you encounter a compatibility issue with Docker bundled binary, try rebuildin
 the image with the build argument `--build-arg DOCKER_VERSION="v$(docker -v | cut -d" " -f3 | rev | cut -c 2- | rev)"`
 so that the bundled docker binary matches your host docker binary version.
 
+### Flox
+
+You can install `lazydocker` using [Flox](https://flox.dev).
+
+```sh
+flox install lazydocker
+```
 
 ## Usage
 


### PR DESCRIPTION
`lazydocker` is available and working in Flox today.

```console
$ cd "$(mktemp -d)"
$ flox init
✨ Created environment 'tmp.exxnTQQsGK' (aarch64-darwin)

Next:
  $ flox search <package>    <- Search for a package
  $ flox install <package>   <- Install a package into an environment
  $ flox activate            <- Enter the environment
  $ flox edit                <- Add environment variables and shell hooks

$ flox install lazydocker
✅ 'lazydocker' installed to environment 'tmp.exxnTQQsGK'
$ flox activate -- lazydocker --version
Version: 0.23.3
Date:
BuildSource: unknown
Commit:
OS: darwin
Arch: arm64
```