### PR TITLE
Added configuration options to hide side panels

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -48,6 +48,13 @@ gui:
   wrapMainPanel: true
   # Side panel width as a ratio of the screen's width
   sidePanelWidth: 0.333
+  # Determines whether each side panel is shown or not
+  sidePanelVisibility:
+    services: true
+    containers: true
+    images: true
+    volumes: true
+    networks: true
   # Determines whether we show the bottom line (the one containing keybinding
   # info and the status of the app).
   showBottomLine: true

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -74,6 +74,15 @@ type ThemeConfig struct {
 	OptionsTextColor    []string `yaml:"optionsTextColor,omitempty"`
 }
 
+// SidePanelVisibilityConfig is for toggling visiblity of side panels.
+type SidePanelVisibilityConfig struct {
+	Services   bool `yaml:"services,omitempty"`
+	Containers bool `yaml:"containers,omitempty"`
+	Images 	   bool `yaml:"images,omitempty"`
+	Volumes    bool `yaml:"volumes,omitempty"`
+	Networks   bool `yaml:"networks,omitempty"`
+}
+
 // GuiConfig is for configuring visual things like colors and whether we show or
 // hide things
 type GuiConfig struct {
@@ -122,6 +131,9 @@ type GuiConfig struct {
 
 	// If 0.333, then the side panels will be 1/3 of the screen's width
 	SidePanelWidth float64 `yaml:"sidePanelWidth"`
+
+	// Determines which side panels to show. Each panel defaults to `true` (visible).
+	SidePanelVisibility SidePanelVisibilityConfig `yaml:"sidePanelVisibility,omitempty"`
 
 	// Determines whether we show the bottom line (the one containing keybinding
 	// info and the status of the app).
@@ -373,6 +385,13 @@ func GetDefaultConfig() UserConfig {
 			WrapMainPanel:              true,
 			LegacySortContainers:       false,
 			SidePanelWidth:             0.3333,
+			SidePanelVisibility: SidePanelVisibilityConfig{
+				Services:   true,
+				Containers: true,
+				Images:     true,
+				Volumes:    true,
+				Networks:   true,
+			},
 			ShowBottomLine:             true,
 			ExpandFocusedSidePanel:     false,
 			ScreenMode:                 "normal",

--- a/pkg/gui/arrangement.go
+++ b/pkg/gui/arrangement.go
@@ -175,11 +175,19 @@ func (gui *Gui) sidePanelChildren(width int, height int) []*boxlayout.Box {
 			return defaultBox
 		}
 
-		return append([]*boxlayout.Box{
-			{
+		projectBox := &boxlayout.Box{
+			Window: sideWindowNames[0],
+			Size: 3,
+		}
+		if len(sideWindowNames) == 1 {
+			projectBox = &boxlayout.Box{
 				Window: sideWindowNames[0],
-				Size:   3,
-			},
+				Weight: 1,
+			}
+		}
+
+		return append([]*boxlayout.Box{
+			projectBox,
 		}, lo.Map(sideWindowNames[1:], func(window string, _ int) *boxlayout.Box {
 			return accordionBox(&boxlayout.Box{Window: window, Weight: 1})
 		})...)

--- a/pkg/gui/containers_panel.go
+++ b/pkg/gui/containers_panel.go
@@ -96,6 +96,7 @@ func (gui *Gui) getContainersPanel() *panels.SideListPanel[*commands.Container] 
 
 			return true
 		},
+		ConfigHidden: !gui.Config.UserConfig.Gui.SidePanelVisibility.Containers,
 		GetTableCells: func(container *commands.Container) []string {
 			return presentation.GetContainerDisplayStrings(&gui.Config.UserConfig.Gui, container)
 		},

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -459,10 +459,15 @@ func (gui *Gui) ShouldRefresh(key string) bool {
 }
 
 func (gui *Gui) initiallyFocusedViewName() string {
-	if gui.DockerCommand.InDockerComposeProject {
+	visiblePanels := gui.Config.UserConfig.Gui.SidePanelVisibility
+	
+	if gui.DockerCommand.InDockerComposeProject && visiblePanels.Services {
 		return "services"
+	} else if visiblePanels.Containers {
+		return "containers"
+	} else {
+		return "project"
 	}
-	return "containers"
 }
 
 func (gui *Gui) IgnoreStrings() []string {

--- a/pkg/gui/images_panel.go
+++ b/pkg/gui/images_panel.go
@@ -62,6 +62,7 @@ func (gui *Gui) getImagesPanel() *panels.SideListPanel[*commands.Image] {
 			return a.ID < b.ID
 		},
 		GetTableCells: presentation.GetImageDisplayStrings,
+		ConfigHidden: !gui.Config.UserConfig.Gui.SidePanelVisibility.Images,
 	}
 }
 

--- a/pkg/gui/networks_panel.go
+++ b/pkg/gui/networks_panel.go
@@ -44,6 +44,7 @@ func (gui *Gui) getNetworksPanel() *panels.SideListPanel[*commands.Network] {
 			return a.Name < b.Name
 		},
 		GetTableCells: presentation.GetNetworkDisplayStrings,
+		ConfigHidden: !gui.Config.UserConfig.Gui.SidePanelVisibility.Networks,
 	}
 }
 

--- a/pkg/gui/panels/side_list_panel.go
+++ b/pkg/gui/panels/side_list_panel.go
@@ -57,6 +57,9 @@ type SideListPanel[T comparable] struct {
 	// set this to true if you don't want to allow manual filtering via '/'
 	DisableFilter bool
 
+	// set to true if config file wants this panel to be hidden
+	ConfigHidden bool
+
 	// This can be nil if you want to always show the panel
 	Hide func() bool
 }
@@ -263,6 +266,10 @@ func (self *SideListPanel[T]) IsFilterDisabled() bool {
 }
 
 func (self *SideListPanel[T]) IsHidden() bool {
+	if self.ConfigHidden {
+		return true
+	}
+
 	if self.Hide == nil {
 		return false
 	}

--- a/pkg/gui/services_panel.go
+++ b/pkg/gui/services_panel.go
@@ -77,6 +77,7 @@ func (gui *Gui) getServicesPanel() *panels.SideListPanel[*commands.Service] {
 		GetTableCells: func(service *commands.Service) []string {
 			return presentation.GetServiceDisplayStrings(&gui.Config.UserConfig.Gui, service)
 		},
+		ConfigHidden: !gui.Config.UserConfig.Gui.SidePanelVisibility.Services,
 		Hide: func() bool {
 			return !gui.DockerCommand.InDockerComposeProject
 		},

--- a/pkg/gui/volumes_panel.go
+++ b/pkg/gui/volumes_panel.go
@@ -50,6 +50,7 @@ func (gui *Gui) getVolumesPanel() *panels.SideListPanel[*commands.Volume] {
 			return a.Name < b.Name
 		},
 		GetTableCells: presentation.GetVolumeDisplayStrings,
+		ConfigHidden: !gui.Config.UserConfig.Gui.SidePanelVisibility.Volumes,
 	}
 }
 


### PR DESCRIPTION
Every panel except "project" can be hidden. All panels are visible by default.
I decided to not let "project" be hidden since a) it's special cased in various layouts and b) it doesn't really make sense to have *no* panels visible at all.

`initiallyFocusedViewName` defaults to "project" if "services" and "containers" are hidden

This should fix #513.