### PR TITLE
README.md: Add x-cmd method to install lazydocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ You can install lazydocker using the [AUR](https://aur.archlinux.org/packages/la
 yay -S lazydocker
 ```
 
+### x-cmd
+
+[x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.
+```sh
+x env use lazydocker
+```
+- Additionally, the [`x lazydocker ...`](https://www.x-cmd.com/pkg/lazydocker) command is available, which automatically download `lazydocker` without affecting the environment, such as not modifying the `PATH` variable.
+
+
 ### Docker
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/lazyteam/lazydocker.svg)](https://hub.docker.com/r/lazyteam/lazydocker)


### PR DESCRIPTION
- Hi, we have implemented a lightweight [package manager using shell and awk](https://www.x-cmd.com/pkg/). It helps you download lazydocker release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the lazydocker README?**[The installation method for the x command](https://www.x-cmd.com/start/) 
  ```sh
  x env use lazydocker 
  ```
- Furthermore, the [`x lazydocker`](https://www.x-cmd.com/pkg/lazydocker) command is provided, which automatically downloads and calls `lazydocker` without affecting the environment, such as not modifying the `PATH` variable.