### PR TITLE
Name of container should be checked first

### DIFF
--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -259,7 +259,7 @@ func (c *DockerCommand) GetContainers(existingContainers []*Container) ([]*Conta
 		} else if name, ok := ctr.Labels["name"]; ok {
 			newContainer.Name = name
 		} else {
-			newContainer.Name = "default_name"
+			newContainer.Name = "Unknown"
 		}
 		newContainer.ServiceName = ctr.Labels["com.docker.compose.service"]
 		newContainer.ProjectName = ctr.Labels["com.docker.compose.project"]


### PR DESCRIPTION
In most of the cases, the base image is used without making any changes and name label is not provided however, in most use cases, name is provided therefore the Name key should be checked first and then label name and if none is given then just default name