### PR TITLE
feat: use bound keys select side panel

### DIFF
--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -127,6 +127,9 @@ type GuiConfig struct {
 	// info and the status of the app).
 	ShowBottomLine bool `yaml:"showBottomLine"`
 
+	// If true, show jump-to-window keybindings in window titles.
+	ShowPanelJumps bool `yaml:"showPanelJumps"`
+
 	// When true, increases vertical space used by focused side panel,
 	// creating an accordion effect
 	ExpandFocusedSidePanel bool `yaml:"expandFocusedSidePanel"`

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -525,7 +525,9 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 	// Mapping number keys to jump between side panels
 	for _, panel := range gui.allSidePanels() {
 		for idx := 1; idx <= len(gui.allSidePanels()); idx++ {
-			bindings = append(bindings, &Binding{ViewName: panel.GetView().Name(), Key: rune('0' + idx), Modifier: gocui.ModNone, Handler: wrappedHandlerWithKey(gui.jumpToSideView, idx)})
+			bindings = append(bindings,
+				&Binding{ViewName: panel.GetView().Name(), Key: rune('0' + idx), Modifier: gocui.ModNone, Handler: wrappedHandlerWithKey(gui.jumpToSideView, idx)},
+			)
 		}
 	}
 

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -522,6 +522,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		}...)
 	}
 
+	// Mapping number keys to jump between side panels
+	for _, panel := range gui.allSidePanels() {
+		for idx := 1; idx <= len(gui.allSidePanels()); idx++ {
+			bindings = append(bindings, &Binding{ViewName: panel.GetView().Name(), Key: rune('0' + idx), Modifier: gocui.ModNone, Handler: wrappedHandlerWithKey(gui.jumpToSideView, idx)})
+		}
+	}
+
 	setUpDownClickBindings := func(viewName string, onUp func() error, onDown func() error, onClick func() error) {
 		bindings = append(bindings, []*Binding{
 			{ViewName: viewName, Key: 'k', Modifier: gocui.ModNone, Handler: wrappedHandler(onUp)},
@@ -600,5 +607,11 @@ func (gui *Gui) keybindings(g *gocui.Gui) error {
 func wrappedHandler(f func() error) func(*gocui.Gui, *gocui.View) error {
 	return func(g *gocui.Gui, v *gocui.View) error {
 		return f()
+	}
+}
+
+func wrappedHandlerWithKey(f func(g *gocui.Gui, key int) error, key int) func(*gocui.Gui, *gocui.View) error {
+	return func(g *gocui.Gui, v *gocui.View) error {
+		return f(g, key)
 	}
 }

--- a/pkg/gui/view_helpers.go
+++ b/pkg/gui/view_helpers.go
@@ -64,6 +64,21 @@ func (gui *Gui) previousView(g *gocui.Gui, v *gocui.View) error {
 	return gui.switchFocus(focusedView)
 }
 
+func (gui *Gui) jumpToSideView(g *gocui.Gui, idx int) error {
+	sideViewNames := gui.sideViewNames()
+	if idx < 1 || len(sideViewNames) < idx {
+		gui.Log.Info("not in list of views")
+		return nil
+	}
+	focusedViewName := sideViewNames[idx-1]
+	focusedView, err := g.View(focusedViewName)
+	if err != nil {
+		panic(err)
+	}
+	gui.resetMainView()
+	return gui.switchFocus(focusedView)
+}
+
 func (gui *Gui) resetMainView() {
 	gui.State.Panels.Main.ObjectKey = ""
 	gui.Views.Main.Wrap = gui.Config.UserConfig.Gui.WrapMainPanel

--- a/pkg/gui/views.go
+++ b/pkg/gui/views.go
@@ -112,6 +112,8 @@ func (gui *Gui) createAllViews() error {
 		(*mapping.viewPtr).FgColor = gocui.ColorDefault
 	}
 
+	gui.configureViewProperties()
+
 	selectedLineBgColor := GetGocuiStyle(gui.Config.UserConfig.Gui.Theme.SelectedLineBgColor)
 
 	gui.Views.Main.Wrap = gui.Config.UserConfig.Gui.WrapMainPanel
@@ -173,6 +175,26 @@ func (gui *Gui) createAllViews() error {
 	gui.Views.Filter.Editor = gocui.EditorFunc(gui.wrapEditor(gocui.SimpleEditor))
 
 	return nil
+}
+
+func (gui *Gui) configureViewProperties() {
+	gui.Config.UserConfig.Gui.ShowPanelJumps = true
+	if gui.Config.UserConfig.Gui.ShowPanelJumps {
+		gui.Views.Project.TitlePrefix = "[1]"
+		// TODO service panel appear condition?
+		gui.Views.Services.TitlePrefix = "[2]"
+		gui.Views.Containers.TitlePrefix = "[3]"
+		gui.Views.Images.TitlePrefix = "[4]"
+		gui.Views.Volumes.TitlePrefix = "[5]"
+		gui.Views.Networks.TitlePrefix = "[6]"
+	} else {
+		gui.Views.Project.TitlePrefix = ""
+		gui.Views.Services.TitlePrefix = ""
+		gui.Views.Containers.TitlePrefix = ""
+		gui.Views.Images.TitlePrefix = ""
+		gui.Views.Volumes.TitlePrefix = ""
+		gui.Views.Networks.TitlePrefix = ""
+	}
 }
 
 func (gui *Gui) setInitialViewContent() error {

--- a/pkg/gui/views.go
+++ b/pkg/gui/views.go
@@ -178,15 +178,24 @@ func (gui *Gui) createAllViews() error {
 }
 
 func (gui *Gui) configureViewProperties() {
-	gui.Config.UserConfig.Gui.ShowPanelJumps = true
 	if gui.Config.UserConfig.Gui.ShowPanelJumps {
-		gui.Views.Project.TitlePrefix = "[1]"
-		// TODO service panel appear condition?
-		gui.Views.Services.TitlePrefix = "[2]"
-		gui.Views.Containers.TitlePrefix = "[3]"
-		gui.Views.Images.TitlePrefix = "[4]"
-		gui.Views.Volumes.TitlePrefix = "[5]"
-		gui.Views.Networks.TitlePrefix = "[6]"
+		// defualt use number key mapping
+		jumpLabels := []string{"[1]", "[2]", "[3]", "[4]", "[5]", "[6]"}
+		idx := 0
+		gui.Views.Project.TitlePrefix = jumpLabels[idx]
+		idx++
+		if gui.DockerCommand.InDockerComposeProject {
+			gui.Views.Services.TitlePrefix = jumpLabels[idx]
+			idx++
+		}
+		gui.Views.Containers.TitlePrefix = jumpLabels[idx]
+		idx++
+		gui.Views.Images.TitlePrefix = jumpLabels[idx]
+		idx++
+		gui.Views.Volumes.TitlePrefix = jumpLabels[idx]
+		idx++
+		gui.Views.Networks.TitlePrefix = jumpLabels[idx]
+		idx++
 	} else {
 		gui.Views.Project.TitlePrefix = ""
 		gui.Views.Services.TitlePrefix = ""


### PR DESCRIPTION
This PR add feature https://github.com/jesseduffield/lazydocker/issues/597

Set the showPanelJumps configuration to true, and use the assigned keys to quickly navigate and select specific panels, similar to how it's done in LazyGit.