### PR TITLE
Add --profile arg for lazydocker command

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,11 +11,12 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/go-errors/errors"
 	"github.com/integrii/flaggy"
+	"github.com/jesseduffield/yaml"
+	"github.com/samber/lo"
+
 	"github.com/jesseduffield/lazydocker/pkg/app"
 	"github.com/jesseduffield/lazydocker/pkg/config"
 	"github.com/jesseduffield/lazydocker/pkg/utils"
-	"github.com/jesseduffield/yaml"
-	"github.com/samber/lo"
 )
 
 const DEFAULT_VERSION = "unversioned"
@@ -29,6 +30,7 @@ var (
 	configFlag    = false
 	debuggingFlag = false
 	composeFiles  []string
+	profiles      []string
 )
 
 func main() {
@@ -51,6 +53,7 @@ func main() {
 	flaggy.Bool(&configFlag, "c", "config", "Print the current default config")
 	flaggy.Bool(&debuggingFlag, "d", "debug", "a boolean")
 	flaggy.StringSlice(&composeFiles, "f", "file", "Specify alternate compose files")
+	flaggy.StringSlice(&profiles, "p", "profile", "Specify one or more profiles to use")
 	flaggy.SetVersion(info)
 
 	flaggy.Parse()
@@ -71,7 +74,7 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	appConfig, err := config.NewAppConfig("lazydocker", version, commit, date, buildSource, debuggingFlag, composeFiles, projectDir)
+	appConfig, err := config.NewAppConfig("lazydocker", version, commit, date, buildSource, debuggingFlag, composeFiles, projectDir, profiles)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/pkg/cheatsheet/generate.go
+++ b/pkg/cheatsheet/generate.go
@@ -33,7 +33,7 @@ func Generate() {
 }
 
 func generateAtDir(dir string) {
-	mConfig, err := config.NewAppConfig("lazydocker", "", "", "", "", true, nil, "")
+	mConfig, err := config.NewAppConfig("lazydocker", "", "", "", "", true, nil, "", nil)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -491,7 +491,7 @@ type AppConfig struct {
 }
 
 // NewAppConfig makes a new app config
-func NewAppConfig(name, version, commit, date string, buildSource string, debuggingFlag bool, composeFiles []string, projectDir string) (*AppConfig, error) {
+func NewAppConfig(name, version, commit, date, buildSource string, debuggingFlag bool, composeFiles []string, projectDir string, profiles []string) (*AppConfig, error) {
 	configDir, err := findOrCreateConfigDir(name)
 	if err != nil {
 		return nil, err
@@ -505,6 +505,10 @@ func NewAppConfig(name, version, commit, date string, buildSource string, debugg
 	// Pass compose files as individual -f flags to docker compose
 	if len(composeFiles) > 0 {
 		userConfig.CommandTemplates.DockerCompose += " -f " + strings.Join(composeFiles, " -f ")
+	}
+
+	if len(profiles) > 0 {
+		userConfig.CommandTemplates.DockerCompose += " --profile " + strings.Join(profiles, " --profile ")
 	}
 
 	appConfig := &AppConfig{

--- a/pkg/config/app_config_test.go
+++ b/pkg/config/app_config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestDockerComposeCommandNoFiles(t *testing.T) {
 	composeFiles := []string{}
-	conf, err := NewAppConfig("name", "version", "commit", "date", "buildSource", false, composeFiles, "projectDir")
+	conf, err := NewAppConfig("name", "version", "commit", "date", "buildSource", false, composeFiles, "projectDir", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -23,7 +23,7 @@ func TestDockerComposeCommandNoFiles(t *testing.T) {
 
 func TestDockerComposeCommandSingleFile(t *testing.T) {
 	composeFiles := []string{"one.yml"}
-	conf, err := NewAppConfig("name", "version", "commit", "date", "buildSource", false, composeFiles, "projectDir")
+	conf, err := NewAppConfig("name", "version", "commit", "date", "buildSource", false, composeFiles, "projectDir", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -37,7 +37,7 @@ func TestDockerComposeCommandSingleFile(t *testing.T) {
 
 func TestDockerComposeCommandMultipleFiles(t *testing.T) {
 	composeFiles := []string{"one.yml", "two.yml", "three.yml"}
-	conf, err := NewAppConfig("name", "version", "commit", "date", "buildSource", false, composeFiles, "projectDir")
+	conf, err := NewAppConfig("name", "version", "commit", "date", "buildSource", false, composeFiles, "projectDir", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -49,10 +49,23 @@ func TestDockerComposeCommandMultipleFiles(t *testing.T) {
 	}
 }
 
+func TestDockerComposeProfiles(t *testing.T) {
+	conf, err := NewAppConfig("name", "version", "commit", "date", "buildSource", false, nil, "projectDir", []string{"profile1", "profile2"})
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+	actual := conf.UserConfig.CommandTemplates.DockerCompose
+	expected := "docker compose --profile profile1 --profile profile2"
+	if actual != expected {
+		t.Fatalf("Expected %s but got %s", expected, actual)
+	}
+}
+
 func TestWritingToConfigFile(t *testing.T) {
 	// init the AppConfig
 	emptyComposeFiles := []string{}
-	conf, err := NewAppConfig("name", "version", "commit", "date", "buildSource", false, emptyComposeFiles, "projectDir")
+	conf, err := NewAppConfig("name", "version", "commit", "date", "buildSource", false, emptyComposeFiles, "projectDir", nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -23,3 +23,19 @@ services:
       dockerfile: Dockerfile
       context: .
     command: /app/print-random-stuff.sh
+
+  my-service4:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    command: /app/print-random-stuff.sh
+    profiles:
+      - foo
+
+  my-service5:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    command: /app/print-random-stuff.sh
+    profiles:
+      - bar


### PR DESCRIPTION
Adds --profile to lazydocker. I know it's possible to use COMPOSE_PROFILES but it can get a bit messy sometimes. 

Ref: https://github.com/jesseduffield/lazydocker/issues/423