### PR TITLE
fix(ssh): use user name in DOCKER_HOST

### DIFF
--- a/pkg/commands/ssh/ssh.go
+++ b/pkg/commands/ssh/ssh.go
@@ -55,7 +55,7 @@ func (self *SSHHandler) HandleSSHDockerHost() (io.Closer, error) {
 
 	// if the docker host scheme is "ssh", forward the docker socket before creating the client
 	if u.Scheme == "ssh" {
-		tunnel, err := self.createDockerHostTunnel(ctx, u.Host)
+		tunnel, err := self.createDockerHostTunnel(ctx, u.User.String() + "@" + u.Host)
 		if err != nil {
 			return noopCloser{}, fmt.Errorf("tunnel ssh docker host: %w", err)
 		}


### PR DESCRIPTION
Noticed this issue when using docker context with `--docker "host=ssh://root@IP"` 
It prompts for a password input with `my_name@IP` when I start the app. 

Cheers!