### PR TITLE
Fix bug `No such file or directory` in  install_update_linux.sh

### DIFF
--- a/scripts/install_update_linux.sh
+++ b/scripts/install_update_linux.sh
@@ -3,6 +3,9 @@
 # allow specifying different destination directory
 DIR="${DIR:-"$HOME/.local/bin"}"
 
+# ensure the directory exists
+mkdir -p "$DIR"
+
 # map different architecture variations to the available binaries
 ARCH=$(uname -m)
 case $ARCH in


### PR DESCRIPTION
Create the directory if it does not exist.
By this fix, we can avoid the error:
`install: failed to access ‘~/.local/bin’: No such file or directory`