### PR TITLE
Readme change to include go version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ The script installs downloaded binary to `$HOME/.local/bin` directory by default
 
 ### Go
 
+Go >= 1.21 is required for lazydocker >= v0.24.0
+
 Required Go Version >= **1.19**
 
 ```sh


### PR DESCRIPTION
lazydocker v0.24.0 and later are not working with 'go' that  is packaged with systems like Debian 12
It would be beneficial to include the 'go' version requirement with the install instructions because errors shown during installation are not helpful.


https://github.com/jesseduffield/lazydocker/issues/619