### PR TITLE
Add project name to docker command

### DIFF
--- a/pkg/gui/project_panel.go
+++ b/pkg/gui/project_panel.go
@@ -80,10 +80,14 @@ func (gui *Gui) refreshProject() error {
 func (gui *Gui) getProjectName() string {
 	projectName := path.Base(gui.Config.ProjectDir)
 	if gui.DockerCommand.InDockerComposeProject {
-		for _, service := range gui.Panels.Services.List.GetAllItems() {
-			container := service.Container
-			if container != nil && container.DetailsLoaded() {
-				return container.Details.Config.Labels["com.docker.compose.project"]
+		if gui.DockerCommand.ProjectName != "" {
+			return gui.DockerCommand.ProjectName
+		} else {
+			for _, service := range gui.Panels.Services.List.GetAllItems() {
+				container := service.Container
+				if container != nil && container.DetailsLoaded() {
+					return container.Details.Config.Labels["com.docker.compose.project"]
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Determing docker compose project name provides the ability to work with services of each docker compose project separately in various Lazydocker instances, even if services have the same names

Determing project name is only available if name explicitly specified in docker compose project config (docker compose v2)