### PR TITLE
Update deprecated actions dependencies

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Unshallow repo
         run: git fetch --prune --unshallow
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
           version: v1.17.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,13 @@ jobs:
       GOFLAGS: -mod=vendor
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - name: Cache build
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/go-build
           key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}-test
@@ -45,13 +45,13 @@ jobs:
       GOARCH: amd64
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - name: Cache build
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/go-build
           key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}-build
@@ -73,13 +73,13 @@ jobs:
       GOARCH: amd64
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - name: Cache build
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -100,13 +100,13 @@ jobs:
       GOFLAGS: -mod=vendor
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21.x
       - name: Cache build
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/go-build
           key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}-test

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate Sponsors 💖
         uses: JamesIves/github-sponsors-readme-action@v1.2.2


### PR DESCRIPTION
We are using older versions of actions that are currently being deprecated and have brownout periods where the CDN doesn't answer for those versions.

https://github.com/actions/cache/discussions/1510
https://github.com/orgs/community/discussions/151729

Bump to latest actions version. Should be retro compatible.