### PR TITLE
Fix CI badge in README (was pointing to lazygit instead of lazydocker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 A simple terminal UI for both docker and docker-compose, written in Go with the [gocui](https://github.com/jroimartin/gocui 'gocui') library.
 
-![CI](https://github.com/jesseduffield/lazygit/workflows/Continuous%20Integration/badge.svg)
+[![CI](https://github.com/jesseduffield/lazydocker/actions/workflows/ci.yml/badge.svg)](https://github.com/jesseduffield/lazydocker/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/jesseduffield/lazydocker)](https://goreportcard.com/report/github.com/jesseduffield/lazydocker)
 [![GolangCI](https://golangci.com/badges/github.com/jesseduffield/lazydocker.svg)](https://golangci.com)
 [![GoDoc](https://godoc.org/github.com/jesseduffield/lazydocker?status.svg)](http://godoc.org/github.com/jesseduffield/lazydocker)


### PR DESCRIPTION
Replaced the incorrect CI badge URL which was referencing the `lazygit` repository and showing a failing status. The new badge correctly points to the `ci.yml` workflow in the `lazydocker` repository.
