### PR TITLE
docs: Add installation method with gah

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ curl https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/i
 ```
 The script installs downloaded binary to `$HOME/.local/bin` directory by default, but it can be changed by setting `DIR` environment variable.
 
+Or if you are using [gah](https://github.com/marverix/gah/):
+
+```sh
+gah install lazydocker
+```
+
 ### Go
 
 Required Go Version >= **1.19**


### PR DESCRIPTION
Hello!
This PR adds to the documentation installation method using [gah](https://github.com/marverix/gah):
> gah is an GitHub Releases app installer, that DOES NOT REQUIRE SUDO! It is a simple bash script that downloads the latest release of an app from GitHub and installs it in ~/.local/bin. It is designed to be used with apps that are distributed as a single binary file.