### PR TITLE
Change default install directory to /usr/local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Automated install/update, don't forget to always verify what you're piping into 
 ```sh
 curl https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/install_update_linux.sh | bash
 ```
-The script installs downloaded binary to `$HOME/.local/bin` directory by default, but it can be changed by setting `DIR` environment variable.
+The script installs downloaded binary to `/usr/local/bin` directory by default, but it can be changed by setting `DIR` environment variable.
 
 ### Go
 
@@ -244,6 +244,12 @@ You can also use `go run main.go` to compile and run in one go (pun definitely i
 ## Usage
 
 Call `lazydocker` in your terminal. I personally use this a lot so I've made an alias for it like so:
+
+```
+echo "alias lzd='lazydocker'" >> ~/.bashrc
+```
+
+Or zsh:
 
 ```
 echo "alias lzd='lazydocker'" >> ~/.zshrc


### PR DESCRIPTION
- Change default DIR from /home/jmeiracorbal/.local/bin to /usr/local/bin, doesn't work if is not present on PATH.
- Add permission or checks if sudo is required for the installation.
- Update README.md to reflect the new default directory.
- Ensure directory creation if it doesn't exist.