### PR TITLE
fix: add reminder for users to update PATH after installation

### DIFF
--- a/scripts/install_update_linux.sh
+++ b/scripts/install_update_linux.sh
@@ -22,3 +22,14 @@ curl -L -o lazydocker.tar.gz $GITHUB_URL
 tar xzvf lazydocker.tar.gz lazydocker
 install -Dm 755 lazydocker -t "$DIR"
 rm lazydocker lazydocker.tar.gz
+
+# remind user to add to PATH if necessary
+if [[ ":$PATH:" != *":$DIR:"* ]]; then
+    echo
+    echo "To finish installing lazydocker, please ensure $DIR is in your PATH."
+    echo
+    echo "Consider running:"
+    echo "    echo 'export PATH=\$PATH:$DIR' >> ~/.bashrc"
+    echo "    source ~/.bashrc"
+    echo "(If you are using a shell other than bash, modify the appropriate configuration file accordingly.)"
+fi


### PR DESCRIPTION
Some Linux systems and Docker environments do not have default installation directory in the PATH. 

This results in `lazydocker: command not found` after a successful install, which may confuse users.

This PR adds a clear post-installation message that warns users when installation DIR (~/.local/bin by default) is missing from their PATH and provides explicit instructions to fix it permanently by updating ~/.bashrc (or another shell configuration file).