### PR TITLE
Error - Incorrect client version detection #698

### DIFF
--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	APIVersion       = "1.25"
+	APIVersion       = "1.44"
 	dockerHostEnvKey = "DOCKER_HOST"
 )
 


### PR DESCRIPTION
changed Docker API version to 1.44

Just changing the variable forks fine for me.
tested on debian 13
