### PR TITLE
Fix: Use Docker API version negotiation instead of hardcoded 1.25

### DIFF
--- a/pkg/commands/docker.go
+++ b/pkg/commands/docker.go
@@ -97,7 +97,7 @@ func NewDockerCommand(log *logrus.Entry, osCommand *OSCommand, tr *i18n.Translat
 		dockerHost = dockerHostFromEnv
 	}
 
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion(APIVersion), client.WithHost(dockerHost))
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation(), client.WithHost(dockerHost))
 	if err != nil {
 		ogLog.Fatal(err)
 	}


### PR DESCRIPTION
- Replace client.WithVersion(APIVersion) with client.WithAPIVersionNegotiation()
- Remove unused APIVersion constant
- Fixes compatibility with Docker daemons requiring API version >= 1.44

Resolves error: 'client version 1.25 is too old. Minimum supported API version is 1.44'