### PR TITLE
Update asdf installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ asdf plugin add lazydocker https://github.com/comdotlinux/asdf-lazydocker.git
 ```sh
 asdf list all lazydocker
 asdf install lazydocker latest
-asdf global lazydocker latest
+asdf set -u lazydocker latest
 ```
 
 ### Binary Release (Linux/OSX/Windows)


### PR DESCRIPTION
`asdf global` and `asdf local` commands have been replaced with `asdf set`.

See: https://asdf-vm.com/guide/upgrading-to-v0-16.html#asdf-global-and-asdf-local-commands-have-been-replaced-with-asdf-set