### PR TITLE
Fix: shows the container name in services window (closes #40)

### DIFF
--- a/pkg/gui/presentation/services.go
+++ b/pkg/gui/presentation/services.go
@@ -32,10 +32,14 @@ func GetServiceDisplayStrings(guiConfig *config.GuiConfig, service *commands.Ser
 	}
 
 	container := service.Container
+	serviceName := service.Name
+	if container != nil && container.Name != "" {
+		serviceName = service.Name + " (" + container.Name + ")"
+	}
 	return []string{
 		getContainerDisplayStatus(guiConfig, container),
 		getContainerDisplaySubstatus(guiConfig, container),
-		service.Name,
+		serviceName,
 		getDisplayCPUPerc(container),
 		utils.ColoredString(displayPorts(container), color.FgYellow),
 		utils.ColoredString(displayContainerImage(container), color.FgMagenta),


### PR DESCRIPTION
This PR adds container name visibility in the Services window.
Previously, LazyDocker displayed only the service name (from docker-compose.yml) but did not show the container’s actual container_name value.
This caused confusion when multiple services used custom container names.

**Problem**
Given a docker-compose.yml like:

services:
```
  mongodb:
    image: mongo
    container_name: "db_app"
  frontend:
    image: quizgame/webclient
    container_name: "web_app"

```

LazyDocker would display:

```
running frontend 0.00%
running mongodb 0.35%

```

But the expected behavior is:

```
running frontend (web_app) 0.00%
running mongodb (db_app) 0.35%

```

**Users want to see both the service name and the actual container name.**

**Fix Implemented**

Updated the UI rendering logic in the Services window.

Added container name retrieval and appended it in parentheses next to each service.

Ensures format:
service_name (container_name)

Works for all containers, including those without a custom container_name (fallback gracefully handled).

Result
Services now correctly display:

```
running frontend (web_app)
running mongodb (db_app)
```
Closes: #40 