### PR TITLE
pass BUILD_DATE argument to go build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM ${BASE_IMAGE_BUILDER}:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 ARG GOARCH=amd64
 ARG GOARM
 ARG VERSION
+ARG BUILD_DATE
 ARG VCS_REF
 WORKDIR /tmp/gobuild
 COPY ./ .
@@ -13,6 +14,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} \
     go build -a -mod=vendor \
     -ldflags="-s -w \
     -X main.commit=${VCS_REF} \
+    -X main.date=${BUILD_DATE} \
     -X main.version=${VERSION} \
     -X main.buildSource=Docker"
 


### PR DESCRIPTION
When executing `lazydocker --version` inside the container, the `Date` field is empty, since, the `BUILD_DATE` wasn't passed during build:

```console
$ docker exec -it LazyDocker /bin/lazydocker --version
Version: v0.24.2
Date:
BuildSource: Docker
Commit: 78edbf3d
OS: linux
Arch: amd64

$ nano Dockerfile
$ git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   Dockerfile

no changes added to commit (use "git add" and/or "git commit -a")
$ git diff Dockerfile
diff --git a/Dockerfile b/Dockerfile
index 334591a0..da876ff3 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM ${BASE_IMAGE_BUILDER}:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
 ARG GOARCH=amd64
 ARG GOARM
 ARG VERSION
+ARG BUILD_DATE
 ARG VCS_REF
 WORKDIR /tmp/gobuild
 COPY ./ .
@@ -13,6 +14,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GOARM=${GOARM} \
     go build -a -mod=vendor \
     -ldflags="-s -w \
     -X main.commit=${VCS_REF} \
+    -X main.date=${BUILD_DATE} \
     -X main.version=${VERSION} \
     -X main.buildSource=Docker"
$ docker build -t lazyteam/lazydocker \
    --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
    --build-arg VCS_REF=`git rev-parse --short HEAD` \
    --build-arg VERSION=`git describe --abbrev=0 --tag` \
    .
[+] Building 12.8s (16/16) FINISHED                                                                                                                                           docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                    0.0s
 => => transferring dockerfile: 1.93kB                                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/golang:1.23-alpine3.20                                                                                                               0.6s
 => [internal] load .dockerignore                                                                                                                                                       0.0s
 => => transferring context: 145B                                                                                                                                                       0.0s
 => [internal] load build context                                                                                                                                                       0.0s
 => => transferring context: 119.89kB                                                                                                                                                   0.0s
 => [builder 1/4] FROM docker.io/library/golang:1.23-alpine3.20@sha256:96917b18cf0bf6dc54f726696eb526fe6e6a1ab45e43d4a292aae11f3d503ffe                                                 0.0s
 => CACHED [builder 2/4] WORKDIR /tmp/gobuild                                                                                                                                           0.0s
 => CACHED [builder 3/4] COPY ./ .                                                                                                                                                      0.0s
 => [builder 4/4] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOARM=${GOARM}     go build -a -mod=vendor     -ldflags="-s -w     -X main.commit=78edbf3d     -X main.date=2025-11-28T09  11.9s
 => CACHED [docker-builder 2/6] RUN apk add -U -q --progress --no-cache git bash coreutils gcc musl-dev                                                                                 0.0s
 => CACHED [docker-builder 3/6] WORKDIR /go/src/github.com/docker/cli                                                                                                                   0.0s
 => CACHED [docker-builder 4/6] RUN git clone --branch v27.0.3 --single-branch --depth 1 https://github.com/docker/cli.git . > /dev/null 2>&1                                           0.0s
 => CACHED [docker-builder 5/6] RUN ./scripts/build/binary                                                                                                                              0.0s
 => CACHED [docker-builder 6/6] RUN rm build/docker && mv build/docker-linux-* build/docker                                                                                             0.0s
 => CACHED [stage-2 1/2] COPY --from=docker-builder /go/src/github.com/docker/cli/build/docker /bin/docker                                                                              0.0s
 => [stage-2 2/2] COPY --from=builder /tmp/gobuild/lazydocker /bin/lazydocker                                                                                                           0.0s
 => exporting to image                                                                                                                                                                  0.1s
 => => exporting layers                                                                                                                                                                 0.1s
 => => writing image sha256:4bed130d21cd24b1c2080f6cefedfe0d4b60510717b4ca0f9e5b51f32e24d4e6                                                                                            0.0s
 => => naming to docker.io/lazyteam/lazydocker
$ docker exec -it LazyDocker /bin/lazydocker --version
Version: v0.24.2
Date: 2025-11-28T09:34:01Z
BuildSource: Docker
Commit: 78edbf3d
OS: linux
Arch: amd64
```