### PR TITLE
Fix: race condition for pause/unpause state

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -363,6 +363,18 @@ outer:
 			case <-ctx.Done():
 				return
 			case message := <-messageChan:
+				switch message.Type {
+				case events.ContainerEventType:
+					switch message.Action {
+					case events.ActionPause, events.ActionUnPause:
+						// pause/unpause events are lonely events
+						// add tiny delay to allow state to stabilise
+						// other events don't need that as they are followed by other events
+						// which give time for state to stabilise and be picked up by our refreshes
+						time.Sleep(200 * time.Millisecond)
+					}
+				}
+
 				// We could be more granular about what events should trigger which refreshes.
 				// At the moment it's pretty efficient though, and it might not be worth
 				// the maintenance burden of mapping specific events to specific refreshes


### PR DESCRIPTION
Hello,

While working on https://github.com/sablierapp/sablier/pull/755 I noticed that lazydocker would report the wrong state for paused containers until another events would refresh and show the proper state.

Here is a video showing the issue:

https://github.com/user-attachments/assets/38d5a55b-44f1-4558-ae05-0987688f215a

The problem is that for usual events like start/stop, they are followed by other events so the race condition is selfhealing, but pause/unpause are lonely events.

I attach a naive fix but I'd like to discuss the approach before going forward and adding tests.
The proposal is to filter pause/unpause events from docker and delay a bit the refresh in that case. 200ms seems to be enough for me.


https://github.com/user-attachments/assets/fb9ecf35-37da-43b5-9bb8-c72c21379d56

Waiting forward for your feedback 