### PR TITLE
Fix color contrast for better readability on dark backgrounds

### DIFF
--- a/pkg/commands/image.go
+++ b/pkg/commands/image.go
@@ -46,7 +46,7 @@ func getHistoryResponseItemDisplayStrings(layer image.HistoryResponseItem) []str
 	}
 	idColor := color.FgWhite
 	if id == "<missing>" {
-		idColor = color.FgBlue
+		idColor = color.FgCyan
 	}
 
 	dockerFileCommandPrefix := "/bin/sh -c #(nop) "
@@ -62,7 +62,7 @@ func getHistoryResponseItemDisplayStrings(layer image.HistoryResponseItem) []str
 	size := utils.FormatBinaryBytes(int(layer.Size))
 	sizeColor := color.FgWhite
 	if size == "0B" {
-		sizeColor = color.FgBlue
+		sizeColor = color.FgCyan
 	}
 
 	return []string{

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -366,7 +366,7 @@ func GetDefaultConfig() UserConfig {
 				ActiveBorderColor:   []string{"green", "bold"},
 				InactiveBorderColor: []string{"default"},
 				SelectedLineBgColor: []string{"blue"},
-				OptionsTextColor:    []string{"blue"},
+				OptionsTextColor:    []string{"cyan"},
 			},
 			ShowAllContainers:          false,
 			ReturnImmediately:          false,

--- a/pkg/gui/presentation/containers.go
+++ b/pkg/gui/presentation/containers.go
@@ -193,7 +193,7 @@ func getContainerColor(c *commands.Container) color.Attribute {
 	case "dead":
 		return color.FgRed
 	case "restarting":
-		return color.FgBlue
+		return color.FgCyan
 	case "removing":
 		return color.FgMagenta
 	default:

--- a/pkg/gui/presentation/services.go
+++ b/pkg/gui/presentation/services.go
@@ -22,7 +22,7 @@ func GetServiceDisplayStrings(guiConfig *config.GuiConfig, service *commands.Ser
 		}
 
 		return []string{
-			utils.ColoredString(containerState, color.FgBlue),
+			utils.ColoredString(containerState, color.FgCyan),
 			"",
 			service.Name,
 			"",

--- a/pkg/gui/subprocess.go
+++ b/pkg/gui/subprocess.go
@@ -54,7 +54,7 @@ func (gui *Gui) runCommand(cmd *exec.Cmd, msg string) {
 		}
 	}()
 
-	fmt.Fprintf(os.Stdout, "\n%s\n\n", utils.ColoredString("+ "+strings.Join(cmd.Args, " "), color.FgBlue))
+	fmt.Fprintf(os.Stdout, "\n%s\n\n", utils.ColoredString("+ "+strings.Join(cmd.Args, " "), color.FgCyan))
 	if msg != "" {
 		fmt.Fprintf(os.Stdout, "\n%s\n\n", utils.ColoredString(msg, color.FgGreen))
 	}


### PR DESCRIPTION
Improved text readability on terminals with dark ANSI blue colors by changing FgBlue to FgCyan in a few places.

I noticed this while using lazydocker with a terminal theme that has dark blue (like the standard ANSI #0000AA). The blue text was pretty hard to read on black backgrounds - especially the keyboard shortcuts at the bottom and some status indicators.

Changed the following to use cyan instead:
- Image history: `<missing>` IDs and `0B` sizes
- Services panel: `none` status  
- Containers: `restarting` state
- Keyboard shortcuts at the bottom
- Command output when running subprocesses

Tested it with both the dark blue theme and normal themes - cyan has way better contrast and doesn't hurt readability on any setup.

Fixes #685