### PR TITLE
Container Environment Variables sorted alphabetically

### DIFF
--- a/pkg/gui/container_env_test.go
+++ b/pkg/gui/container_env_test.go
@@ -1,0 +1,87 @@
+package gui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/jesseduffield/lazydocker/pkg/commands"
+	"github.com/jesseduffield/lazydocker/pkg/i18n"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainerEnvAlphabeticalSorting(t *testing.T) {
+	// Create a mock Gui with minimal setup
+	log := logrus.NewEntry(logrus.New())
+	gui := &Gui{
+		Log: log,
+		Tr:  i18n.NewTranslationSet(log, "en"),
+	}
+
+	// Create a container with unsorted environment variables
+	c := &commands.Container{}
+	c.Details = container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{},
+		Config: &container.Config{
+			Env: []string{
+				"ZEBRA=value1",
+				"ALPHA=value2",
+				"MIDDLE=value3",
+				"BETA=value4",
+			},
+		},
+	}
+
+	// Call containerEnv
+	result := gui.containerEnv(c)
+
+	// The result should contain environment variables in alphabetical order
+	// Check that ALPHA comes before BETA, BETA before MIDDLE, and MIDDLE before ZEBRA
+	alphaIndex := strings.Index(result, "ALPHA")
+	betaIndex := strings.Index(result, "BETA")
+	middleIndex := strings.Index(result, "MIDDLE")
+	zebraIndex := strings.Index(result, "ZEBRA")
+
+	assert.True(t, alphaIndex >= 0, "ALPHA should be present in result")
+	assert.True(t, betaIndex >= 0, "BETA should be present in result")
+	assert.True(t, middleIndex >= 0, "MIDDLE should be present in result")
+	assert.True(t, zebraIndex >= 0, "ZEBRA should be present in result")
+
+	assert.True(t, alphaIndex < betaIndex, "ALPHA should come before BETA")
+	assert.True(t, betaIndex < middleIndex, "BETA should come before MIDDLE")
+	assert.True(t, middleIndex < zebraIndex, "MIDDLE should come before ZEBRA")
+}
+
+func TestContainerEnvEmptyEnvironment(t *testing.T) {
+	log := logrus.NewEntry(logrus.New())
+	gui := &Gui{
+		Log: log,
+		Tr:  i18n.NewTranslationSet(log, "en"),
+	}
+
+	c := &commands.Container{}
+	c.Details = container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{},
+		Config: &container.Config{
+			Env: []string{},
+		},
+	}
+
+	result := gui.containerEnv(c)
+	assert.Contains(t, result, gui.Tr.NothingToDisplay)
+}
+
+func TestContainerEnvDetailsNotLoaded(t *testing.T) {
+	log := logrus.NewEntry(logrus.New())
+	gui := &Gui{
+		Log: log,
+		Tr:  i18n.NewTranslationSet(log, "en"),
+	}
+
+	c := &commands.Container{}
+	// Details is not properly initialized, so DetailsLoaded() will return false
+
+	result := gui.containerEnv(c)
+	assert.Contains(t, result, gui.Tr.WaitingForContainerInfo)
+}

--- a/pkg/gui/containers_panel.go
+++ b/pkg/gui/containers_panel.go
@@ -3,6 +3,7 @@ package gui
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -135,7 +136,12 @@ func (gui *Gui) containerEnv(container *commands.Container) string {
 		return gui.Tr.NothingToDisplay
 	}
 
-	envVarsList := lo.Map(container.Details.Config.Env, func(envVar string, _ int) []string {
+	// Create a sorted copy of the environment variables
+	sortedEnv := make([]string, len(container.Details.Config.Env))
+	copy(sortedEnv, container.Details.Config.Env)
+	sort.Strings(sortedEnv)
+
+	envVarsList := lo.Map(sortedEnv, func(envVar string, _ int) []string {
 		splitEnv := strings.SplitN(envVar, "=", 2)
 		key := splitEnv[0]
 		value := ""


### PR DESCRIPTION
# Summary

This introduces Container "Environment Variable" aplhabetical sorting.
It bugged me for a while since current random order of env variables made it hard to find values I was looking for in containers with a lot of variables.

Old Behavior:
<img width="1351" height="1264" alt="image" src="https://github.com/user-attachments/assets/49a0c757-86da-4ebc-b8c0-64a857adefcd" />

New Behavior:
<img width="1339" height="1285" alt="image" src="https://github.com/user-attachments/assets/929da3e1-17e8-4713-a46d-2c81fe68afae" />
