### PR TITLE
Update README links to use relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,16 @@ What a headache!
 
 Memorising docker commands is hard. Memorising aliases is slightly less hard. Keeping track of your containers across multiple terminal windows is near impossible. What if you had all the information you needed in one terminal window with every common command living one keypress away (and the ability to add custom commands as well). Lazydocker's goal is to make that dream a reality.
 
-- [Requirements](https://github.com/jesseduffield/lazydocker#requirements)
-- [Installation](https://github.com/jesseduffield/lazydocker#installation)
-- [Usage](https://github.com/jesseduffield/lazydocker#usage)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Usage](#usage)
 - [Keybindings](/docs/keybindings)
-- [Cool Features](https://github.com/jesseduffield/lazydocker#cool-features)
-- [Contributing](https://github.com/jesseduffield/lazydocker#contributing)
+- [Cool Features](#cool-features)
+- [Contributing](#contributing)
 - [Video Tutorial](https://youtu.be/NICqQPxwJWw)
 - [Config Docs](/docs/Config.md)
 - [Twitch Stream](https://www.twitch.tv/jesseduffield)
-- [FAQ](https://github.com/jesseduffield/lazydocker#faq)
+- [FAQ](#faq)
 
 ## Requirements
 


### PR DESCRIPTION
This pull request updates the `README.md` file to improve the usability and reliability of internal documentation links. The most important change is switching several section links to use relative anchors instead of absolute GitHub URLs, making navigation within the README more consistent and user-friendly.

This should help to go to the correct location instead of hopping to the top of the page.

Documentation improvements:

* Updated section links for Requirements, Installation, Usage, Cool Features, Contributing, and FAQ to use relative anchors (e.g., `#requirements`) instead of full GitHub URLs, ensuring they work correctly within the README itself.