### PR TITLE
fix: use `DiskUsage` instead of `VolumeList` to populate `Volume.UsageData`

### DIFF
--- a/pkg/commands/volume.go
+++ b/pkg/commands/volume.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
@@ -21,7 +22,7 @@ type Volume struct {
 
 // RefreshVolumes gets the volumes and stores them
 func (c *DockerCommand) RefreshVolumes() ([]*Volume, error) {
-	result, err := c.Client.VolumeList(context.Background(), volume.ListOptions{})
+	result, err := c.Client.DiskUsage(context.Background(), types.DiskUsageOptions{Types: []types.DiskUsageObject{types.VolumeObject}})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gui/volumes_panel.go
+++ b/pkg/gui/volumes_panel.go
@@ -78,7 +78,7 @@ func (gui *Gui) volumeConfigStr(volume *commands.Volume) string {
 	}
 
 	if volume.Volume.UsageData != nil {
-		output += utils.WithPadding("RefCount: ", padding) + fmt.Sprintf("%d", volume.Volume.UsageData.RefCount) + "\n"
+		output += "\n" + utils.WithPadding("RefCount: ", padding) + fmt.Sprintf("%d", volume.Volume.UsageData.RefCount) + "\n"
 		output += utils.WithPadding("Size: ", padding) + utils.FormatBinaryBytes(int(volume.Volume.UsageData.Size)) + "\n"
 	}
 


### PR DESCRIPTION
Fixes #450 

## Explanation: 
The renderer of volumes list already had support for displaying `Volume.UsageData`: https://github.com/jesseduffield/lazydocker/blob/577797d9ed11463f220c0c5d0acb86b521c1d21d/pkg/gui/volumes_panel.go#L80-L83

But it was never displayed, since according to `Volume.UsageData` field comment it was available _only_ when using `/system/df` endpoint:
https://github.com/jesseduffield/lazydocker/blob/577797d9ed11463f220c0c5d0acb86b521c1d21d/vendor/github.com/docker/docker/api/types/volume/volume.go#L56-L75

Since `DiskUsage` returns literally the same `Volume` type as `VolumeList` - I was able to simply swap method calls (and add option to fetch only volumes data) and was proud to finally see `Size` and `RefCount` of my docker volume.

## Before
<img width="2542" height="1392" alt="image" src="https://github.com/user-attachments/assets/fe2cfe97-b3c5-4d81-ac7d-cb6599b69343" />

## After
<img width="2542" height="1395" alt="image" src="https://github.com/user-attachments/assets/65744241-ca82-4888-bc75-eec36c506322" />
