### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Unshallow repo
         run: git fetch --prune --unshallow
       - name: Setup Go
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.24.x
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: v1.17.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,13 @@ jobs:
       GOFLAGS: -mod=vendor
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
           go-version: 1.24.x
       - name: Cache build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/go-build
           key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}-test
@@ -45,13 +45,13 @@ jobs:
       GOARCH: amd64
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
           go-version: 1.24.x
       - name: Cache build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/go-build
           key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}-build
@@ -73,13 +73,13 @@ jobs:
       GOARCH: amd64
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
           go-version: 1.24.x
       - name: Cache build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/go-build
@@ -100,20 +100,20 @@ jobs:
       GOFLAGS: -mod=vendor
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
           go-version: 1.24.x
       - name: Cache build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/go-build
           key: ${{runner.os}}-go-${{hashFiles('**/go.sum')}}-test
           restore-keys: |
             ${{runner.os}}-go-
       - name: Lint
-        uses: golangci/golangci-lint-action@v3.1.0
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
       - name: Format code

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Generate Sponsors 💖
         uses: JamesIves/github-sponsors-readme-action@v1.2.2
@@ -19,7 +19,7 @@ jobs:
         if: ${{ github.repository == 'jesseduffield/lazydocker' }}
 
       - name: Create Pull Request 🚀
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "README.md: Update Sponsors"
           title: "README.md: Update Sponsors"


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/cd.yml`
- Updated `peter-evans/create-pull-request` from `v6` to `v8` in `.github/workflows/sponsors.yml`
- Updated `golangci/golangci-lint-action` from `v3.1.0` to `v9` in `.github/workflows/ci.yml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/ci.yml`
- Updated `goreleaser/goreleaser-action` from `v1` to `v6` in `.github/workflows/cd.yml`
- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/sponsors.yml`
- Updated `actions/cache` from `v4` to `v5` in `.github/workflows/ci.yml`
