### PR TITLE
docs: update Arch install instructions to pacman

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ Required Go version >= **1.8**, <= **1.17**
 go get github.com/jesseduffield/lazydocker
 ```
 
-### Arch Linux AUR
+### Arch Linux
 
-You can install lazydocker using the [AUR](https://aur.archlinux.org/packages/lazydocker) by running:
+You can install lazydocker from the official Arch repositories by running:
 
 ```sh
-yay -S lazydocker
+sudo pacman -S lazydocker
 ```
 
 ### Docker


### PR DESCRIPTION
## Summary
- replace the Arch Linux AUR section with Arch Linux
- update installation instructions to use the official repository command
- replace `yay -S lazydocker` with `sudo pacman -S lazydocker`

## Why
lazydocker is available in Arch official repositories, so users should be pointed to the native package manager path first.