### PR TITLE
Force Remove Option for Containers

### DIFF
--- a/pkg/gui/containers_panel.go
+++ b/pkg/gui/containers_panel.go
@@ -334,6 +334,14 @@ func (gui *Gui) handleContainersRemoveMenu(g *gocui.Gui, v *gocui.View) error {
 			LabelColumns: []string{gui.Tr.RemoveWithVolumes, "docker rm --volumes " + ctr.ID[1:10]},
 			OnPress:      func() error { return handleMenuPress(container.RemoveOptions{RemoveVolumes: true}) },
 		},
+		{
+			LabelColumns: []string{gui.Tr.ForceRemove, "docker rm --force " + ctr.ID[1:10]},
+			OnPress:      func() error { return handleMenuPress(container.RemoveOptions{Force: true}) },
+		},
+		{
+			LabelColumns: []string{gui.Tr.ForceRemoveWithVolumes, "docker rm --force --volumes " + ctr.ID[1:10]},
+			OnPress:      func() error { return handleMenuPress(container.RemoveOptions{Force: true, RemoveVolumes: true}) },
+		},
 	}
 
 	return gui.Menu(CreateMenuOptions{

--- a/pkg/i18n/chinese.go
+++ b/pkg/i18n/chinese.go
@@ -43,6 +43,7 @@ func chineseSet() TranslationSet {
 		Remove:            "移除",
 		HideStopped:       "隐藏/显示已停止的容器",
 		ForceRemove:       "强制移除",
+		ForceRemoveWithVolumes: "强制移除并删除卷",
 		RemoveWithVolumes: "移除并删除卷",
 		RemoveService:     "移除容器",
 		UpService:         "启动服务",

--- a/pkg/i18n/dutch.go
+++ b/pkg/i18n/dutch.go
@@ -33,6 +33,7 @@ func dutchSet() TranslationSet {
 		Remove:             "verwijder",
 		HideStopped:        "verberg gestopte containers",
 		ForceRemove:        "geforceerd verwijderen",
+		ForceRemoveWithVolumes: "geforceerd verwijderen met volumes",
 		RemoveWithVolumes:  "verwijder met volumes",
 		RemoveService:      "verwijder containers",
 		Stop:               "stop",

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -35,6 +35,7 @@ type TranslationSet struct {
 	HideStopped                 string
 	ForceRemove                 string
 	RemoveWithVolumes           string
+	ForceRemoveWithVolumes      string
 	MustForceToRemoveContainer  string
 	Confirm                     string
 	Return                      string
@@ -180,6 +181,7 @@ func englishSet() TranslationSet {
 		Remove:                      "remove",
 		HideStopped:                 "hide/show stopped containers",
 		ForceRemove:                 "force remove",
+		ForceRemoveWithVolumes:      "force remove with volumes",
 		RemoveWithVolumes:           "remove with volumes",
 		RemoveService:               "remove containers",
 		UpService:                   "up service",

--- a/pkg/i18n/french.go
+++ b/pkg/i18n/french.go
@@ -39,6 +39,7 @@ func frenchSet() TranslationSet {
 		Remove:                      "supprimer",
 		HideStopped:                 "cacher/montrer les conteneurs arrêtés",
 		ForceRemove:                 "forcer la suppression",
+		ForceRemoveWithVolumes:      "forcer la suppression avec les volumes",
 		RemoveWithVolumes:           "supprimer avec les volumes",
 		RemoveService:               "supprimer les conteneurs",
 		Stop:                        "arrêter",

--- a/pkg/i18n/german.go
+++ b/pkg/i18n/german.go
@@ -32,6 +32,7 @@ func germanSet() TranslationSet {
 		Cancel:             "abbrechen",
 		Remove:             "entfernen",
 		ForceRemove:        "Entfernen erzwingen",
+		ForceRemoveWithVolumes: "Entfernen erzwingen mit Volumes",
 		RemoveWithVolumes:  "entferne mit Volumes",
 		RemoveService:      "entferne Container",
 		Stop:               "anhalten",

--- a/pkg/i18n/polish.go
+++ b/pkg/i18n/polish.go
@@ -32,6 +32,7 @@ func polishSet() TranslationSet {
 		Cancel:             "anuluj",
 		Remove:             "usuń",
 		ForceRemove:        "usuń siłą",
+		ForceRemoveWithVolumes: "usuń siłą z wolumenami",
 		RemoveWithVolumes:  "usuń z wolumenami",
 		RemoveService:      "usuń kontenery",
 		Stop:               "zatrzymaj",

--- a/pkg/i18n/portuguese.go
+++ b/pkg/i18n/portuguese.go
@@ -43,6 +43,7 @@ func portugueseSet() TranslationSet {
 		Remove:                      "remover",
 		HideStopped:                 "ocultar/mostrar contêineres parados",
 		ForceRemove:                 "forçar remoção",
+		ForceRemoveWithVolumes:      "forçar remoção com volumes",
 		RemoveWithVolumes:           "remover com volumes",
 		RemoveService:               "remover contêineres",
 		UpService:                   "subir serviço",

--- a/pkg/i18n/spanish.go
+++ b/pkg/i18n/spanish.go
@@ -39,6 +39,7 @@ func spanishSet() TranslationSet {
 		Remove:                      "borrar",
 		HideStopped:                 "esconder/mostrar contenedores parados",
 		ForceRemove:                 "borrar(forzado)",
+		ForceRemoveWithVolumes:      "borrar(forzado) con volúmenes",
 		RemoveWithVolumes:           "borrar con volúmenes",
 		RemoveService:               "borrar contenedores",
 		UpService:                   "levantar servicio",


### PR DESCRIPTION
### Summary
Adds two options to the container remove menu so users can remove running containers without stopping them first (equivalent to docker rm --force).
Fixes/Implements: #748

### Changes
* Force remove – `docker rm --force <container>`. Uses existing gui.Tr.ForceRemove. Calls Container.Remove with RemoveOptions{Force: true}.
* Force remove with volumes – `docker rm --force --volumes <container>`. Uses gui.Tr.ForceRemoveWithVolumes. Calls Container.Remove with RemoveOptions{Force: true, RemoveVolumes: true}.

### i18n
* Added ForceRemoveWithVolumes to the translation set and to all language files in pkg/i18n/ for the second menu label.
