### PR TITLE
Fix #752: Network containers showing 'none' in config panel

### DIFF
--- a/pkg/commands/network.go
+++ b/pkg/commands/network.go
@@ -29,9 +29,17 @@ func (c *DockerCommand) RefreshNetworks() ([]*Network, error) {
 	ownNetworks := make([]*Network, len(networks))
 
 	for i, nw := range networks {
+		// NetworkList returns network.Summary which doesn't include container
+		// details. We need to inspect each network to populate Containers.
+		inspected, err := c.Client.NetworkInspect(context.Background(), nw.ID, network.InspectOptions{})
+		if err != nil {
+			c.Log.WithError(err).Warn("failed to inspect network " + nw.Name)
+			inspected = nw
+		}
+
 		ownNetworks[i] = &Network{
 			Name:          nw.Name,
-			Network:       nw,
+			Network:       inspected,
 			Client:        c.Client,
 			OSCommand:     c.OSCommand,
 			Log:           c.Log,


### PR DESCRIPTION
Root cause: NetworkList API returns network.Summary which doesn't populate Containers. Switched to NetworkInspect which returns the full network resource including container mappings. Clean one-file fix in pkg/commands/network.go. Tested on macOS ARM (Apple Silicon).