### PR TITLE
fix: Freeze when pressing o when with project pane selected - shoul...

### DIFF
--- a/pkg/commands/os.go
+++ b/pkg/commands/os.go
@@ -161,8 +161,12 @@ func (c *OSCommand) OpenFile(filename string) error {
 	}
 
 	command := utils.ResolvePlaceholderString(commandTemplate, templateValues)
-	err := c.RunCommand(command)
-	return err
+	cmd := c.ExecutableFromString(command)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go cmd.Wait()
+	return nil
 }
 
 // OpenLink opens a file with the given
@@ -173,8 +177,12 @@ func (c *OSCommand) OpenLink(link string) error {
 	}
 
 	command := utils.ResolvePlaceholderString(commandTemplate, templateValues)
-	err := c.RunCommand(command)
-	return err
+	cmd := c.ExecutableFromString(command)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go cmd.Wait()
+	return nil
 }
 
 // EditFile opens a file in a subprocess using whatever editor is available,


### PR DESCRIPTION
## Summary

Fixes a freeze when pressing 'o' with the project pane selected by making file and link opening operations asynchronous. Previously, the `OpenFile` and `OpenLink` functions used blocking command execution, which caused the UI to hang until the opened application closed.

## Issue

Fixes #688

## Changes

- Modified `OpenFile` to use asynchronous command execution with `cmd.Start()` and `go cmd.Wait()` instead of blocking `RunCommand`
- Modified `OpenLink` to use the same asynchronous pattern for consistency

## Testing

- Verified that pressing 'o' with the project pane selected now opens the config file without freezing the UI
- Confirmed that opening links still works correctly and does not block the interface