### PR TITLE
Update Config.md

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -8,7 +8,7 @@ Changes to the user config will only take place after closing and re-opening laz
 
 ### Locations:
 
-- OSX: `~/Library/Application Support/jesseduffield/lazydocker/config.yml`
+- macOS: `~/Library/Application Support/lazydocker/config.yml`
 - Linux: `~/.config/lazydocker/config.yml`
 - Windows: `C:\Users\<User>\AppData\Roaming\lazydocker\config.yml`
 


### PR DESCRIPTION
Update the path to the config file as it appears to no longer be accurate. Also pedantically change "OSX" to "macOS" to align with modern naming convention.