### PR TITLE
Feature: show container names in Services panel

### DIFF
--- a/pkg/gui/presentation/services.go
+++ b/pkg/gui/presentation/services.go
@@ -32,10 +32,14 @@ func GetServiceDisplayStrings(guiConfig *config.GuiConfig, service *commands.Ser
 	}
 
 	container := service.Container
+	displayName := service.Name
+	if container.Name != "" && container.Name != service.Name {
+		displayName = service.Name + " (" + container.Name + ")"
+	}
 	return []string{
 		getContainerDisplayStatus(guiConfig, container),
 		getContainerDisplaySubstatus(guiConfig, container),
-		service.Name,
+		displayName,
 		getDisplayCPUPerc(container),
 		utils.ColoredString(displayPorts(container), color.FgYellow),
 		utils.ColoredString(displayContainerImage(container), color.FgMagenta),


### PR DESCRIPTION
This PR implements the feature request in #40 by displaying container names alongside service names in the Services panel.

**Changes:**
- Modified  to show container name in parentheses when it differs from the service name
- Example display: `frontend (web_app)` instead of just `frontend`

**Testing:**
- The change correctly identifies when a container has a custom name
- Container name is only shown if it differs from the service name
- Follows the existing code style and conventions

Fixes #40