### PR TITLE
Feature: add clear logs functionality

### DIFF
--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -462,6 +462,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Handler:  gui.scrollRightMain,
 		},
 		{
+			ViewName:    "main",
+			Key:         gocui.KeyCtrlL,
+			Modifier:    gocui.ModNone,
+			Handler:     wrappedHandler(gui.handleClearMain),
+			Description: gui.Tr.ClearMain,
+		},
+		{
 			ViewName: "filter",
 			Key:      gocui.KeyEnter,
 			Modifier: gocui.ModNone,

--- a/pkg/gui/main_panel.go
+++ b/pkg/gui/main_panel.go
@@ -98,6 +98,15 @@ func (gui *Gui) handleExitMain(g *gocui.Gui, v *gocui.View) error {
 	return gui.returnFocus()
 }
 
+func (gui *Gui) handleClearMain() error {
+	if gui.popupPanelFocused() {
+		return nil
+	}
+
+	gui.Views.Main.Clear()
+	return nil
+}
+
 func (gui *Gui) handleMainClick() error {
 	if gui.popupPanelFocused() {
 		return nil

--- a/pkg/i18n/english.go
+++ b/pkg/i18n/english.go
@@ -39,6 +39,7 @@ type TranslationSet struct {
 	Confirm                     string
 	Return                      string
 	FocusMain                   string
+	ClearMain                   string
 	LcFilter                    string
 	StopContainer               string
 	RestartingStatus            string
@@ -166,6 +167,7 @@ func englishSet() TranslationSet {
 
 		Return:                      "return",
 		FocusMain:                   "focus main panel",
+		ClearMain:                   "clear logs",
 		LcFilter:                    "filter list",
 		Navigate:                    "navigate",
 		Execute:                     "execute",


### PR DESCRIPTION
## What does this PR do?

This PR adds the ability to clear the logs view in the main panel by pressing Ctrl+L.

## Why is it needed?

When checking logs across multiple containers, it's helpful to clear the old logs and only see new items as they come in. This is already possible when viewing logs independently (via the m keybind), but not within the lazydocker main context.

## Implementation

- Added handleClearMain() function in pkg/gui/main_panel.go that clears the main panel's content
- Added keybinding for Ctrl+L in pkg/gui/keybindings.go that triggers the clear function
- Added translation text ClearMain: "clear logs" in pkg/i18n/english.go

## Testing

To test:
1. Open lazydocker and view logs for any container
2. Press Ctrl+L while focused on the main panel
3. The logs should be cleared and only new logs will appear

## Related Issue

Fixes #403
