### PR TITLE
fix: show containers in network config view

### DIFF
--- a/pkg/commands/network.go
+++ b/pkg/commands/network.go
@@ -48,6 +48,11 @@ func (c *DockerCommand) PruneNetworks() error {
 	return err
 }
 
+// Inspect fetches the full network details including containers
+func (v *Network) Inspect() (network.Inspect, error) {
+	return v.Client.NetworkInspect(context.Background(), v.Network.ID, network.InspectOptions{})
+}
+
 // Remove removes the network
 func (v *Network) Remove() error {
 	return v.Client.NetworkRemove(context.Background(), v.Name)

--- a/pkg/gui/networks_panel.go
+++ b/pkg/gui/networks_panel.go
@@ -64,9 +64,10 @@ func (gui *Gui) networkConfigStr(network *commands.Network) string {
 	output += utils.WithPadding("Ingress: ", padding) + strconv.FormatBool(network.Network.Ingress) + "\n"
 
 	output += utils.WithPadding("Containers: ", padding)
-	if len(network.Network.Containers) > 0 {
+	inspected, err := network.Inspect()
+	if err == nil && len(inspected.Containers) > 0 {
 		output += "\n"
-		for _, v := range network.Network.Containers {
+		for _, v := range inspected.Containers {
 			output += utils.FormatMapItem(padding, v.Name, v.EndpointID)
 		}
 	} else {


### PR DESCRIPTION
When selecting a network, the config panel always shows `Containers: none` even when containers are attached to it.

The `NetworkList` API doesn't populate the `Containers` field — only `NetworkInspect` does. The config renderer was reading from the list response, which is always empty.

Added a `Network.Inspect()` method and call it when rendering the config panel to fetch the full network details including connected containers.

Fixes #752