### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook alongside the existing `PostToolUse` gofumpt hook.

Closes #779

---
_Disclosure: I am the author and maintainer of `block-no-verify`._