### PR TITLE
fix: blank screen after returning from exec shell

### DIFF
--- a/vendor/github.com/jesseduffield/gocui/gui.go
+++ b/vendor/github.com/jesseduffield/gocui/gui.go
@@ -1546,7 +1546,18 @@ func (g *Gui) Resume() error {
 
 	g.suspended = false
 
-	return g.screen.Resume()
+	if err := g.screen.Resume(); err != nil {
+		return err
+	}
+
+	// Resume() re-engages the terminal but leaves tcell's internal
+	// "last drawn" cell cache stale. Without Sync(), the next redraw
+	// diffs against that stale cache, finds nothing changed, and
+	// writes nothing — leaving the screen blank. Sync() invalidates
+	// the cache so the next Show() forces a full repaint.
+	g.screen.Sync()
+
+	return nil
 }
 
 // matchView returns if the keybinding matches the current view (and the view's context)


### PR DESCRIPTION
## what's broken

after exec-ing into a container (`shift+e`) and exiting (`ctrl+d`), the screen goes completely blank. only way to recover is killing and relaunching lazydocker. happens on kitty, warp, and wsl, basically any modern terminal.

## why it happens

gocui's `Resume()` calls `tcell.Screen.Resume()` which re-engages the terminal, but tcell's internal cell cache still thinks the old pre-suspend content is on screen. when gocui tries to redraw, it diffs against that stale cache, decides nothing changed, and writes nothing. blank screen.

## the fix

one line: `g.screen.Sync()` after `Resume()`. this invalidates tcell's cache so the next draw cycle does a full repaint instead of diffing against stale data.

credit to @AbrhamSayd who identified the root cause and opened the upstream fix at jesseduffield/gocui#101. this PR applies the same fix directly to lazydocker's vendored gocui so it can ship without waiting on an upstream merge.

## tested

- kitty + orbstack on macOS. exec into container, ctrl+d out, clean redraw every time

fixes #611