### PR TITLE
fix: handle donate link error gracefully on headless systems

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -423,7 +423,10 @@ func (gui *Gui) handleDonate(g *gocui.Gui, v *gocui.View) error {
 	if cx > len(gui.Tr.Donate) {
 		return nil
 	}
-	return gui.OSCommand.OpenLink("https://github.com/sponsors/jesseduffield")
+	if err := gui.OSCommand.OpenLink("https://github.com/sponsors/jesseduffield"); err != nil {
+		return gui.createErrorPanel(err.Error())
+	}
+	return nil
 }
 
 func (gui *Gui) editFile(filename string) error {


### PR DESCRIPTION
## what's broken

clicking the donate link on a headless server crashes lazydocker. the system doesn't have `xdg-open` installed, `OpenLink` returns an error, and it bubbles up unhandled to gocui's event loop which treats it as fatal. been open for 3 years.

## the fix

catch the error and show it in an error panel instead of crashing. this is the same pattern `openFile` already uses literally three lines below `handleDonate` in the same file, it was just missed here.

## tested

simulated a headless environment by swapping `OpenLinkCommand` to `xdg-open` on macOS (where it doesn't exist). before the fix: crash. after: error panel renders cleanly with `exec: "xdg-open": executable file not found in $PATH`.

<img width="1752" height="1832" alt="CleanShot 2026-03-21 at 12 29 19@2x" src="https://github.com/user-attachments/assets/027ec2c6-6243-4ba7-96b4-f14ff5e06930" />

fixes #437