### PR TITLE
fix: sanitize subprocess call in client.go

### DIFF
--- a/vendor/github.com/docker/docker-credential-helpers/client/client.go
+++ b/vendor/github.com/docker/docker-credential-helpers/client/client.go
@@ -9,6 +9,16 @@ import (
 	"github.com/docker/docker-credential-helpers/credentials"
 )
 
+// validateServerURL checks that the serverURL does not contain characters that
+// could be used to inject additional protocol messages into the credential helper
+// stdin stream (e.g. newline characters used in line-delimited protocols).
+func validateServerURL(serverURL string) error {
+	if strings.ContainsAny(serverURL, "\n\r") {
+		return fmt.Errorf("invalid serverURL: must not contain newline characters")
+	}
+	return nil
+}
+
 // isValidCredsMessage checks if 'msg' contains invalid credentials error message.
 // It returns whether the logs are free of invalid credentials errors and the error if it isn't.
 // error values can be errCredentialsMissingServerURL or errCredentialsMissingUsername.
@@ -45,6 +55,9 @@ func Store(program ProgramFunc, creds *credentials.Credentials) error {
 
 // Get executes an external program to get the credentials from a native store.
 func Get(program ProgramFunc, serverURL string) (*credentials.Credentials, error) {
+	if err := validateServerURL(serverURL); err != nil {
+		return nil, err
+	}
 	cmd := program(credentials.ActionGet)
 	cmd.Input(strings.NewReader(serverURL))
 
@@ -74,6 +87,9 @@ func Get(program ProgramFunc, serverURL string) (*credentials.Credentials, error
 
 // Erase executes a program to remove the server credentials from the native store.
 func Erase(program ProgramFunc, serverURL string) error {
+	if err := validateServerURL(serverURL); err != nil {
+		return err
+	}
 	cmd := program(credentials.ActionErase)
 	cmd.Input(strings.NewReader(serverURL))
 	out, err := cmd.Output()


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `vendor/github.com/docker/docker-credential-helpers/client/client.go`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `vendor/github.com/docker/docker-credential-helpers/client/client.go:49` |

**Description**: The Docker credential helper client passes the serverURL value directly into cmd.Input() at client.go lines 49 and 78 using strings.NewReader(serverURL) without any sanitization or validation. The Shell helper's Input() method at command.go:52 accepts this data and feeds it to the credential helper subprocess via stdin. If the serverURL originates from user-controlled input such as a git remote URL or Docker registry configuration file, an attacker can craft a malicious serverURL containing newline characters or shell metacharacters. Depending on the underlying credential helper implementation, injected newlines may cause the helper to interpret additional lines as separate protocol messages or shell commands, potentially executing attacker-controlled operations on the host.

## Changes
- `vendor/github.com/docker/docker-credential-helpers/client/client.go`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
