### PR TITLE
feat: show container name alongside service name when different

### DIFF
--- a/pkg/gui/presentation/services.go
+++ b/pkg/gui/presentation/services.go
@@ -1,6 +1,8 @@
 package presentation
 
 import (
+	"fmt"
+
 	"github.com/fatih/color"
 	"github.com/jesseduffield/lazydocker/pkg/commands"
 	"github.com/jesseduffield/lazydocker/pkg/config"
@@ -32,10 +34,15 @@ func GetServiceDisplayStrings(guiConfig *config.GuiConfig, service *commands.Ser
 	}
 
 	container := service.Container
+	displayName := service.Name
+	if container.Name != "" && container.Name != service.Name {
+		displayName = fmt.Sprintf("%s (%s)", service.Name, container.Name)
+	}
+
 	return []string{
 		getContainerDisplayStatus(guiConfig, container),
 		getContainerDisplaySubstatus(guiConfig, container),
-		service.Name,
+		displayName,
 		getDisplayCPUPerc(container),
 		utils.ColoredString(displayPorts(container), color.FgYellow),
 		utils.ColoredString(displayContainerImage(container), color.FgMagenta),


### PR DESCRIPTION
Closes #40.

**Why:** When a service in `docker-compose.yml` has a `container_name` set that differs from the service name, the Services panel only shows the service name. Users who set custom container names have no way to see them at a glance.

**What changed:** In `GetServiceDisplayStrings`, if the container's actual name differs from the service name, the display string becomes `service (container)` — e.g. `frontend (web_app)`. When the names are the same (the common case), nothing changes.

**Before:**
```
running frontend 0.00%
running mongodb 0.35%
```

**After (with container_name set in docker-compose.yml):**
```
running frontend (web_app) 0.00%
running mongodb (db_app) 0.35%
```