### PR TITLE
feat: log syntax highlight, mouse toggle auto-restore, and external pager support

### DIFF
--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -384,7 +384,7 @@ func GetDefaultConfig() UserConfig {
 			Timestamps: false,
 			Since:      "60m",
 			Tail:       "",
-			Pager:      "",
+			Pager:      "less -R",
 		},
 		CommandTemplates: CommandTemplatesConfig{
 			DockerCompose:            "docker compose",

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -344,6 +344,7 @@ type LogsConfig struct {
 	Timestamps bool   `yaml:"timestamps,omitempty"`
 	Since      string `yaml:"since,omitempty"`
 	Tail       string `yaml:"tail,omitempty"`
+	Pager      string `yaml:"pager,omitempty"` // Configuration for external logs viewer (e.g. "lnav", "less -R")
 }
 
 // GetDefaultConfig returns the application default configuration NOTE (to
@@ -383,6 +384,7 @@ func GetDefaultConfig() UserConfig {
 			Timestamps: false,
 			Since:      "60m",
 			Tail:       "",
+			Pager:      "",
 		},
 		CommandTemplates: CommandTemplatesConfig{
 			DockerCompose:            "docker compose",

--- a/pkg/gui/container_logs.go
+++ b/pkg/gui/container_logs.go
@@ -1,16 +1,19 @@
 package gui
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"os/signal"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/fatih/color"
+	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazydocker/pkg/commands"
 	"github.com/jesseduffield/lazydocker/pkg/tasks"
 	"github.com/jesseduffield/lazydocker/pkg/utils"
@@ -136,17 +139,134 @@ func (gui *Gui) writeContainerLogs(ctr *commands.Container, ctx context.Context,
 		}
 	}
 
+	stdoutWriter := NewLogWriter(writer, false)
+	stderrWriter := NewLogWriter(writer, true)
+	defer stdoutWriter.Close()
+	defer stderrWriter.Close()
+
 	if ctr.Details.Config.Tty {
-		_, err = io.Copy(writer, readCloser)
+		_, err = io.Copy(stdoutWriter, readCloser)
 		if err != nil {
 			return err
 		}
 	} else {
-		_, err = stdcopy.StdCopy(writer, writer, readCloser)
+		_, err = stdcopy.StdCopy(stdoutWriter, stderrWriter, readCloser)
 		if err != nil {
 			return err
 		}
 	}
 
+	return nil
+}
+
+type LogWriter struct {
+	writer     io.Writer
+	lineBuffer []byte
+	isStderr   bool
+}
+
+func NewLogWriter(writer io.Writer, isStderr bool) *LogWriter {
+	return &LogWriter{
+		writer:     writer,
+		lineBuffer: make([]byte, 0),
+		isStderr:   isStderr,
+	}
+}
+
+func (lw *LogWriter) Write(p []byte) (n int, err error) {
+	n = len(p)
+	lw.lineBuffer = append(lw.lineBuffer, p...)
+
+	for {
+		idx := bytes.IndexByte(lw.lineBuffer, '\n')
+		if idx == -1 {
+			break
+		}
+
+		line := string(lw.lineBuffer[:idx])
+		lw.lineBuffer = lw.lineBuffer[idx+1:]
+
+		colorised := utils.ColoriseLog(line)
+		if lw.isStderr {
+			colorised = "\x1b[31;1m" + colorised + "\x1b[0m"
+		}
+
+		_, err = fmt.Fprintln(lw.writer, colorised)
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, nil
+}
+
+func (lw *LogWriter) Close() error {
+	if len(lw.lineBuffer) > 0 {
+		line := string(lw.lineBuffer)
+		colorised := utils.ColoriseLog(line)
+		if lw.isStderr {
+			colorised = "\x1b[31;1m" + colorised + "\x1b[0m"
+		}
+		_, err := fmt.Fprint(lw.writer, colorised)
+		return err
+	}
+	return nil
+}
+
+func (gui *Gui) handleContainerViewLogsExternal(g *gocui.Gui, v *gocui.View) error {
+	ctr, err := gui.Panels.Containers.GetSelectedItem()
+	if err != nil {
+		return nil
+	}
+	return gui.handleViewLogsExternal(ctr)
+}
+
+func (gui *Gui) handleViewLogsExternal(container *commands.Container) error {
+	pager := gui.Config.UserConfig.Logs.Pager
+	if pager == "" {
+		return gui.createErrorPanel("No external pager configured. Please set 'logs.pager' in config.yml")
+	}
+
+	stop := make(chan os.Signal, 1)
+	defer signal.Stop(stop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		signal.Notify(stop, os.Interrupt)
+		<-stop
+		cancel()
+	}()
+
+	if err := gui.g.Suspend(); err != nil {
+		gui.Log.Error(err)
+		return err
+	}
+
+	defer func() {
+		if err := gui.g.Resume(); err != nil {
+			gui.Log.Error(err)
+		}
+	}()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", pager)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	reader, writer := io.Pipe()
+	cmd.Stdin = reader
+
+	if err := cmd.Start(); err != nil {
+		reader.Close()
+		writer.Close()
+		fmt.Fprintf(os.Stdout, "\nError starting pager command: %v\n", err)
+		gui.promptToReturn()
+		return err
+	}
+
+	go func() {
+		defer writer.Close()
+		_ = gui.writeContainerLogs(container, ctx, writer)
+	}()
+
+	_ = cmd.Wait()
 	return nil
 }

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -75,6 +75,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Handler:  gui.quit,
 		},
 		{
+			ViewName:    "",
+			Key:         'M', // Shift+M
+			Modifier:    gocui.ModNone,
+			Handler:     wrappedHandler(gui.handleToggleMouse),
+			Description: "Toggle mouse mode (ON/OFF)",
+		},
+		{
 			ViewName: "",
 			Key:      gocui.KeyPgup,
 			Modifier: gocui.ModNone,
@@ -236,6 +243,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		},
 		{
 			ViewName:    "containers",
+			Key:         'l',
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleContainerViewLogsExternal,
+			Description: "View logs with external pager",
+		},
+		{
+			ViewName:    "containers",
 			Key:         'E',
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleContainersExecShell,
@@ -317,6 +331,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleServiceRenderLogsToMain,
 			Description: gui.Tr.ViewLogs,
+		},
+		{
+			ViewName:    "services",
+			Key:         'l',
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleServiceViewLogsExternal,
+			Description: "View logs with external pager",
 		},
 		{
 			ViewName:    "services",

--- a/pkg/gui/main_panel.go
+++ b/pkg/gui/main_panel.go
@@ -2,6 +2,8 @@ package gui
 
 import (
 	"math"
+	"sync"
+	"time"
 
 	"github.com/jesseduffield/gocui"
 )
@@ -110,4 +112,85 @@ func (gui *Gui) handleMainClick() error {
 	}
 
 	return gui.switchFocus(gui.Views.Main)
+}
+
+var (
+	mouseTimerMutex sync.Mutex
+	mouseTimer      *time.Timer
+	mouseTicker     *time.Ticker
+	mouseTicksLeft  int
+)
+
+func (gui *Gui) handleToggleMouse() error {
+	mouseTimerMutex.Lock()
+	defer mouseTimerMutex.Unlock()
+
+	if gui.g.Mouse {
+		// Disable Mouse
+		gui.g.Mouse = false
+		gocui.Screen.DisableMouse()
+
+		if mouseTimer != nil {
+			mouseTimer.Stop()
+		}
+		if mouseTicker != nil {
+			mouseTicker.Stop()
+		}
+
+		mouseTicksLeft = 15
+		mouseTimer = time.AfterFunc(15*time.Second, func() {
+			gui.g.Update(func(g *gocui.Gui) error {
+				mouseTimerMutex.Lock()
+				defer mouseTimerMutex.Unlock()
+
+				if !gui.g.Mouse {
+					gui.g.Mouse = true
+					gocui.Screen.EnableMouse()
+					if mouseTicker != nil {
+						mouseTicker.Stop()
+					}
+					_ = gui.renderString(gui.g, "information", gui.getInformationContent())
+				}
+				return nil
+			})
+		})
+
+		mouseTicker = time.NewTicker(1 * time.Second)
+		go func() {
+			for range mouseTicker.C {
+				gui.g.Update(func(g *gocui.Gui) error {
+					mouseTimerMutex.Lock()
+					defer mouseTimerMutex.Unlock()
+
+					if gui.g.Mouse {
+						return nil
+					}
+					mouseTicksLeft--
+					if mouseTicksLeft <= 0 {
+						if mouseTicker != nil {
+							mouseTicker.Stop()
+						}
+						return nil
+					}
+					_ = gui.renderString(gui.g, "information", gui.getInformationContent())
+					return nil
+				})
+			}
+		}()
+
+	} else {
+		// Enable Mouse manually
+		gui.g.Mouse = true
+		gocui.Screen.EnableMouse()
+
+		if mouseTimer != nil {
+			mouseTimer.Stop()
+		}
+		if mouseTicker != nil {
+			mouseTicker.Stop()
+		}
+	}
+
+	_ = gui.renderString(gui.g, "information", gui.getInformationContent())
+	return nil
 }

--- a/pkg/gui/services_panel.go
+++ b/pkg/gui/services_panel.go
@@ -333,6 +333,17 @@ func (gui *Gui) handleServiceRenderLogsToMain(g *gocui.Gui, v *gocui.View) error
 	return gui.runSubprocess(c)
 }
 
+func (gui *Gui) handleServiceViewLogsExternal(g *gocui.Gui, v *gocui.View) error {
+	service, err := gui.Panels.Services.GetSelectedItem()
+	if err != nil {
+		return nil
+	}
+	if service.Container == nil {
+		return gui.createErrorPanel("No container running for this service")
+	}
+	return gui.handleViewLogsExternal(service.Container)
+}
+
 func (gui *Gui) handleProjectUp(g *gocui.Gui, v *gocui.View) error {
 	project, _ := gui.Panels.Projects.GetSelectedItem()
 	if project != nil && project.Name != gui.DockerCommand.LocalProjectName {

--- a/pkg/gui/views.go
+++ b/pkg/gui/views.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/fatih/color"
@@ -195,6 +196,13 @@ func (gui *Gui) setInitialViewContent() error {
 
 func (gui *Gui) getInformationContent() string {
 	informationStr := gui.Config.Version
+
+	mouseStatus := "Mouse: ON"
+	if !gui.g.Mouse {
+		mouseStatus = fmt.Sprintf("Mouse: OFF (%ds left)", mouseTicksLeft)
+	}
+	informationStr = mouseStatus + " | " + informationStr
+
 	if !gui.g.Mouse {
 		return informationStr
 	}

--- a/pkg/utils/logs.go
+++ b/pkg/utils/logs.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	errRegex   = regexp.MustCompile(`(?i)\b(error|err|critical|fatal)\b`)
+	warnRegex  = regexp.MustCompile(`(?i)\b(warning|warn)\b`)
+	infoRegex  = regexp.MustCompile(`(?i)\b(info)\b`)
+	debugRegex = regexp.MustCompile(`(?i)\b(debug)\b`)
+
+	timestampRegex = regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\b`)
+)
+
+// ColoriseLog applies basic ANSI syntax highlighting to typical log statements.
+func ColoriseLog(line string) string {
+	if strings.Contains(line, "\x1b[") {
+		return line
+	}
+
+	line = timestampRegex.ReplaceAllStringFunc(line, func(ts string) string {
+		return "\x1b[90m" + ts + "\x1b[0m"
+	})
+
+	line = errRegex.ReplaceAllStringFunc(line, func(match string) string {
+		return "\x1b[31;1m" + match + "\x1b[0m"
+	})
+	line = warnRegex.ReplaceAllStringFunc(line, func(match string) string {
+		return "\x1b[33;1m" + match + "\x1b[0m"
+	})
+	line = infoRegex.ReplaceAllStringFunc(line, func(match string) string {
+		return "\x1b[32m" + match + "\x1b[0m"
+	})
+	line = debugRegex.ReplaceAllStringFunc(line, func(match string) string {
+		return "\x1b[34m" + match + "\x1b[0m"
+	})
+
+	return line
+}

--- a/pkg/utils/logs_test.go
+++ b/pkg/utils/logs_test.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestColoriseLog(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		contains []string
+	}{
+		{
+			name:     "Highlight error log level",
+			input:    "ERROR: database failed to connect",
+			contains: []string{"\x1b[31;1mERROR\x1b[0m"},
+		},
+		{
+			name:     "Highlight warning log level",
+			input:    "[WARN] deprecation warning",
+			contains: []string{"\x1b[33;1mWARN\x1b[0m"},
+		},
+		{
+			name:     "Highlight timestamp",
+			input:    "2026-06-04T12:00:00Z something happened",
+			contains: []string{"\x1b[90m2026-06-04T12:00:00Z\x1b[0m"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ColoriseLog(tt.input)
+			for _, c := range tt.contains {
+				if !strings.Contains(got, c) {
+					t.Errorf("expected %q to contain %q, but it was %q", got, c, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- **Log Syntax Highlighting & Stderr Wrapping**: Introduced a rules-based regex colorizer for levels (`INFO`, `WARN`, `ERROR`, `DEBUG`) and timestamps. Intercepted stderr stream to wrap logs in ANSI red.
- **Mouse Capture Toggle with Auto-Restore**: Bound `Shift+M` globally to toggle mouse capture with a 15-second auto-restore countdown, displaying the status in the bottom panel.
- **External Pager Integration**: Added `logs.pager` config option and bound `l` inside container/service logs views to launch it (e.g. `lnav`, `less -R`) under a suspended state.

## Test Plan
- Run unit tests: `GOFLAGS=-mod=vendor go test ./...`
- Verify `Shift+M` turns mouse capture off and triggers a 15-second visual countdown.
- Confirm standard drag-and-copy (`Cmd+C`) works while mouse capture is OFF, and capture auto-restores to ON when countdown hits 0.
- Verify pressing `l` in logs view opens the logs in the configured pager (e.g., `lnav`) and resumes lazydocker smoothly on exit.