### PR TITLE
feat: log colorization, auto mouse toggling, external pager, and Korean keyboard support

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,0 +1,2 @@
+logs:
+  pager: "lnav"

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -64,6 +64,7 @@ logs:
   timestamps: false
   since: '60m' # set to '' to show all logs
   tail: '' # set to 200 to show last 200 lines of logs
+  pager: 'less -R' # command for external logs pager (e.g. 'less -R', 'lnav')
 commandTemplates:
   dockerCompose: docker compose # Determines the Docker Compose command to run, referred to as .DockerCompose in commandTemplates
   restartService: '{{ .DockerCompose }} restart {{ .Service.Name }}'

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -384,7 +384,7 @@ func GetDefaultConfig() UserConfig {
 			Timestamps: false,
 			Since:      "60m",
 			Tail:       "",
-			Pager:      "",
+			Pager:      "less -R",
 		},
 		CommandTemplates: CommandTemplatesConfig{
 			DockerCompose:            "docker compose",

--- a/pkg/config/app_config.go
+++ b/pkg/config/app_config.go
@@ -344,6 +344,7 @@ type LogsConfig struct {
 	Timestamps bool   `yaml:"timestamps,omitempty"`
 	Since      string `yaml:"since,omitempty"`
 	Tail       string `yaml:"tail,omitempty"`
+	Pager      string `yaml:"pager,omitempty"` // Configuration for external logs viewer (e.g. "lnav", "less -R")
 }
 
 // GetDefaultConfig returns the application default configuration NOTE (to
@@ -383,6 +384,7 @@ func GetDefaultConfig() UserConfig {
 			Timestamps: false,
 			Since:      "60m",
 			Tail:       "",
+			Pager:      "",
 		},
 		CommandTemplates: CommandTemplatesConfig{
 			DockerCompose:            "docker compose",

--- a/pkg/gui/container_logs.go
+++ b/pkg/gui/container_logs.go
@@ -221,6 +221,16 @@ func (gui *Gui) handleContainerViewLogsExternal(g *gocui.Gui, v *gocui.View) err
 	return gui.handleViewLogsExternal(ctr)
 }
 
+func (gui *Gui) handleMainViewLogsExternal(g *gocui.Gui, v *gocui.View) error {
+	currentSideViewName := gui.currentSideViewName()
+	if currentSideViewName == "containers" {
+		return gui.handleContainerViewLogsExternal(g, v)
+	} else if currentSideViewName == "services" {
+		return gui.handleServiceViewLogsExternal(g, v)
+	}
+	return nil
+}
+
 func (gui *Gui) handleViewLogsExternal(container *commands.Container) error {
 	pager := gui.Config.UserConfig.Logs.Pager
 	if pager == "" {

--- a/pkg/gui/container_logs.go
+++ b/pkg/gui/container_logs.go
@@ -1,16 +1,19 @@
 package gui
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"os/signal"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/fatih/color"
+	"github.com/jesseduffield/gocui"
 	"github.com/jesseduffield/lazydocker/pkg/commands"
 	"github.com/jesseduffield/lazydocker/pkg/tasks"
 	"github.com/jesseduffield/lazydocker/pkg/utils"
@@ -136,17 +139,134 @@ func (gui *Gui) writeContainerLogs(ctr *commands.Container, ctx context.Context,
 		}
 	}
 
+	stdoutWriter := NewLogWriter(writer, false)
+	stderrWriter := NewLogWriter(writer, true)
+	defer stdoutWriter.Close()
+	defer stderrWriter.Close()
+
 	if ctr.Details.Config.Tty {
-		_, err = io.Copy(writer, readCloser)
+		_, err = io.Copy(stdoutWriter, readCloser)
 		if err != nil {
 			return err
 		}
 	} else {
-		_, err = stdcopy.StdCopy(writer, writer, readCloser)
+		_, err = stdcopy.StdCopy(stdoutWriter, stderrWriter, readCloser)
 		if err != nil {
 			return err
 		}
 	}
 
+	return nil
+}
+
+type LogWriter struct {
+	writer     io.Writer
+	lineBuffer []byte
+	isStderr   bool
+}
+
+func NewLogWriter(writer io.Writer, isStderr bool) *LogWriter {
+	return &LogWriter{
+		writer:     writer,
+		lineBuffer: make([]byte, 0),
+		isStderr:   isStderr,
+	}
+}
+
+func (lw *LogWriter) Write(p []byte) (n int, err error) {
+	n = len(p)
+	lw.lineBuffer = append(lw.lineBuffer, p...)
+
+	for {
+		idx := bytes.IndexByte(lw.lineBuffer, '\n')
+		if idx == -1 {
+			break
+		}
+
+		line := string(lw.lineBuffer[:idx])
+		lw.lineBuffer = lw.lineBuffer[idx+1:]
+
+		colorised := utils.ColoriseLog(line)
+		if lw.isStderr {
+			colorised = "\x1b[31;1m" + colorised + "\x1b[0m"
+		}
+
+		_, err = fmt.Fprintln(lw.writer, colorised)
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, nil
+}
+
+func (lw *LogWriter) Close() error {
+	if len(lw.lineBuffer) > 0 {
+		line := string(lw.lineBuffer)
+		colorised := utils.ColoriseLog(line)
+		if lw.isStderr {
+			colorised = "\x1b[31;1m" + colorised + "\x1b[0m"
+		}
+		_, err := fmt.Fprint(lw.writer, colorised)
+		return err
+	}
+	return nil
+}
+
+func (gui *Gui) handleContainerViewLogsExternal(g *gocui.Gui, v *gocui.View) error {
+	ctr, err := gui.Panels.Containers.GetSelectedItem()
+	if err != nil {
+		return nil
+	}
+	return gui.handleViewLogsExternal(ctr)
+}
+
+func (gui *Gui) handleViewLogsExternal(container *commands.Container) error {
+	pager := gui.Config.UserConfig.Logs.Pager
+	if pager == "" {
+		return gui.createErrorPanel("No external pager configured. Please set 'logs.pager' in config.yml")
+	}
+
+	stop := make(chan os.Signal, 1)
+	defer signal.Stop(stop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		signal.Notify(stop, os.Interrupt)
+		<-stop
+		cancel()
+	}()
+
+	if err := gui.g.Suspend(); err != nil {
+		gui.Log.Error(err)
+		return err
+	}
+
+	defer func() {
+		if err := gui.g.Resume(); err != nil {
+			gui.Log.Error(err)
+		}
+	}()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", pager)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	reader, writer := io.Pipe()
+	cmd.Stdin = reader
+
+	if err := cmd.Start(); err != nil {
+		reader.Close()
+		writer.Close()
+		fmt.Fprintf(os.Stdout, "\nError starting pager command: %v\n", err)
+		gui.promptToReturn()
+		return err
+	}
+
+	go func() {
+		defer writer.Close()
+		_ = gui.writeContainerLogs(container, ctx, writer)
+	}()
+
+	_ = cmd.Wait()
 	return nil
 }

--- a/pkg/gui/container_logs.go
+++ b/pkg/gui/container_logs.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -226,15 +227,35 @@ func (gui *Gui) handleViewLogsExternal(container *commands.Container) error {
 		return gui.createErrorPanel("No external pager configured. Please set 'logs.pager' in config.yml")
 	}
 
+	tmpFile, err := os.CreateTemp("", "lazydocker-*.log")
+	if err != nil {
+		return gui.createErrorPanel(err.Error())
+	}
+	tmpPath := tmpFile.Name()
+	defer func() {
+		tmpFile.Close()
+		_ = os.Remove(tmpPath)
+	}()
+
 	stop := make(chan os.Signal, 1)
 	defer signal.Stop(stop)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	go func() {
 		signal.Notify(stop, os.Interrupt)
 		<-stop
 		cancel()
 	}()
+
+	// Start writing container logs to the temporary file in background
+	go func() {
+		_ = gui.writeContainerLogs(container, ctx, tmpFile)
+	}()
+
+	// Wait briefly for some logs to be written so the pager has content on start
+	time.Sleep(200 * time.Millisecond)
 
 	if err := gui.g.Suspend(); err != nil {
 		gui.Log.Error(err)
@@ -247,26 +268,18 @@ func (gui *Gui) handleViewLogsExternal(container *commands.Container) error {
 		}
 	}()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", pager)
+	var cmdStr string
+	if strings.Contains(pager, "{{filename}}") {
+		cmdStr = strings.ReplaceAll(pager, "{{filename}}", tmpPath)
+	} else {
+		cmdStr = pager + " " + tmpPath
+	}
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", cmdStr)
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	reader, writer := io.Pipe()
-	cmd.Stdin = reader
-
-	if err := cmd.Start(); err != nil {
-		reader.Close()
-		writer.Close()
-		fmt.Fprintf(os.Stdout, "\nError starting pager command: %v\n", err)
-		gui.promptToReturn()
-		return err
-	}
-
-	go func() {
-		defer writer.Close()
-		_ = gui.writeContainerLogs(container, ctx, writer)
-	}()
-
-	_ = cmd.Wait()
+	_ = cmd.Run()
 	return nil
 }

--- a/pkg/gui/focus.go
+++ b/pkg/gui/focus.go
@@ -46,6 +46,23 @@ func (gui *Gui) switchFocusAux(newView *gocui.View) error {
 
 	gui.g.Cursor = newView.Editable
 
+	// Automatically control mouse capture mode depending on focus
+	if newView.Name() == "main" {
+		if gui.g.Mouse {
+			gui.g.Mouse = false
+			gocui.Screen.DisableMouse()
+		}
+	} else {
+		if !gui.Config.UserConfig.Gui.IgnoreMouseEvents {
+			if !gui.g.Mouse {
+				gui.g.Mouse = true
+				gocui.Screen.EnableMouse()
+			}
+		}
+	}
+	// Force refresh the bottom information panel with updated status text
+	_ = gui.renderString(gui.g, "information", gui.getInformationContent())
+
 	if err := gui.renderPanelOptions(); err != nil {
 		return err
 	}

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -3,6 +3,7 @@ package gui
 import (
 	"fmt"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/jesseduffield/gocui"
 )
 
@@ -609,7 +610,7 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		}
 	}
 
-	return bindings
+	return translateKeybindingsToKorean(bindings)
 }
 
 func (gui *Gui) keybindings(g *gocui.Gui) error {
@@ -632,4 +633,87 @@ func wrappedHandler(f func() error) func(*gocui.Gui, *gocui.View) error {
 	return func(g *gocui.Gui, v *gocui.View) error {
 		return f()
 	}
+}
+
+type koreanKey struct {
+	key      rune
+	modifier gocui.Modifier
+}
+
+var englishToKorean = map[rune]koreanKey{
+	// Lowercase
+	'q': {key: 'ㅂ', modifier: gocui.ModNone},
+	'w': {key: 'ㅈ', modifier: gocui.ModNone},
+	'e': {key: 'ㄷ', modifier: gocui.ModNone},
+	'r': {key: 'ㄱ', modifier: gocui.ModNone},
+	't': {key: 'ㅅ', modifier: gocui.ModNone},
+	'y': {key: 'ㅛ', modifier: gocui.ModNone},
+	'u': {key: 'ㅕ', modifier: gocui.ModNone},
+	'i': {key: 'ㅑ', modifier: gocui.ModNone},
+	'o': {key: 'ㅐ', modifier: gocui.ModNone},
+	'p': {key: 'ㅔ', modifier: gocui.ModNone},
+	'a': {key: 'ㅁ', modifier: gocui.ModNone},
+	's': {key: 'ㄴ', modifier: gocui.ModNone},
+	'd': {key: 'ㅇ', modifier: gocui.ModNone},
+	'f': {key: 'ㄹ', modifier: gocui.ModNone},
+	'g': {key: 'ㅎ', modifier: gocui.ModNone},
+	'h': {key: 'ㅗ', modifier: gocui.ModNone},
+	'j': {key: 'ㅓ', modifier: gocui.ModNone},
+	'k': {key: 'ㅏ', modifier: gocui.ModNone},
+	'l': {key: 'ㅣ', modifier: gocui.ModNone},
+	'z': {key: 'ㅋ', modifier: gocui.ModNone},
+	'x': {key: 'ㅌ', modifier: gocui.ModNone},
+	'c': {key: 'ㅊ', modifier: gocui.ModNone},
+	'v': {key: 'ㅍ', modifier: gocui.ModNone},
+	'b': {key: 'ㅠ', modifier: gocui.ModNone},
+	'n': {key: 'ㅜ', modifier: gocui.ModNone},
+	'm': {key: 'ㅡ', modifier: gocui.ModNone},
+
+	// Uppercase (Double Consonants - ModNone)
+	'Q': {key: 'ㅃ', modifier: gocui.ModNone},
+	'W': {key: 'ㅉ', modifier: gocui.ModNone},
+	'E': {key: 'ㄸ', modifier: gocui.ModNone},
+	'R': {key: 'ㄲ', modifier: gocui.ModNone},
+	'T': {key: 'ㅆ', modifier: gocui.ModNone},
+	'O': {key: 'ㅒ', modifier: gocui.ModNone},
+	'P': {key: 'ㅖ', modifier: gocui.ModNone},
+
+	// Uppercase (No Double Consonant - ModShift)
+	'A': {key: 'ㅁ', modifier: gocui.Modifier(tcell.ModShift)},
+	'S': {key: 'ㄴ', modifier: gocui.Modifier(tcell.ModShift)},
+	'D': {key: 'ㅇ', modifier: gocui.Modifier(tcell.ModShift)},
+	'F': {key: 'ㄹ', modifier: gocui.Modifier(tcell.ModShift)},
+	'G': {key: 'ㅎ', modifier: gocui.Modifier(tcell.ModShift)},
+	'H': {key: 'ㅗ', modifier: gocui.Modifier(tcell.ModShift)},
+	'J': {key: 'ㅓ', modifier: gocui.Modifier(tcell.ModShift)},
+	'K': {key: 'ㅏ', modifier: gocui.Modifier(tcell.ModShift)},
+	'L': {key: 'ㅣ', modifier: gocui.Modifier(tcell.ModShift)},
+	'Z': {key: 'ㅋ', modifier: gocui.Modifier(tcell.ModShift)},
+	'X': {key: 'ㅌ', modifier: gocui.Modifier(tcell.ModShift)},
+	'C': {key: 'ㅊ', modifier: gocui.Modifier(tcell.ModShift)},
+	'V': {key: 'ㅍ', modifier: gocui.Modifier(tcell.ModShift)},
+	'B': {key: 'ㅠ', modifier: gocui.Modifier(tcell.ModShift)},
+	'N': {key: 'ㅜ', modifier: gocui.Modifier(tcell.ModShift)},
+	'M': {key: 'ㅡ', modifier: gocui.Modifier(tcell.ModShift)},
+	'Y': {key: 'ㅛ', modifier: gocui.Modifier(tcell.ModShift)},
+	'U': {key: 'ㅕ', modifier: gocui.Modifier(tcell.ModShift)},
+	'I': {key: 'ㅑ', modifier: gocui.Modifier(tcell.ModShift)},
+}
+
+func translateKeybindingsToKorean(bindings []*Binding) []*Binding {
+	var translated []*Binding
+	for _, binding := range bindings {
+		if r, ok := binding.Key.(rune); ok {
+			if kor, exists := englishToKorean[r]; exists {
+				translated = append(translated, &Binding{
+					ViewName:    binding.ViewName,
+					Handler:     binding.Handler,
+					Key:         kor.key,
+					Modifier:    binding.Modifier | kor.modifier,
+					Description: binding.Description,
+				})
+			}
+		}
+	}
+	return append(bindings, translated...)
 }

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -75,6 +75,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Handler:  gui.quit,
 		},
 		{
+			ViewName:    "",
+			Key:         'M', // Shift+M
+			Modifier:    gocui.ModNone,
+			Handler:     wrappedHandler(gui.handleToggleMouse),
+			Description: "Toggle mouse mode (ON/OFF)",
+		},
+		{
 			ViewName: "",
 			Key:      gocui.KeyPgup,
 			Modifier: gocui.ModNone,
@@ -236,6 +243,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 		},
 		{
 			ViewName:    "containers",
+			Key:         'l',
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleContainerViewLogsExternal,
+			Description: "View logs with external pager",
+		},
+		{
+			ViewName:    "containers",
 			Key:         'E',
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleContainersExecShell,
@@ -317,6 +331,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Modifier:    gocui.ModNone,
 			Handler:     gui.handleServiceRenderLogsToMain,
 			Description: gui.Tr.ViewLogs,
+		},
+		{
+			ViewName:    "services",
+			Key:         'l',
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleServiceViewLogsExternal,
+			Description: "View logs with external pager",
 		},
 		{
 			ViewName:    "services",

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -74,13 +74,7 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Modifier: gocui.ModNone,
 			Handler:  gui.quit,
 		},
-		{
-			ViewName:    "",
-			Key:         'M', // Shift+M
-			Modifier:    gocui.ModNone,
-			Handler:     wrappedHandler(gui.handleToggleMouse),
-			Description: "Toggle mouse mode (ON/OFF)",
-		},
+
 		{
 			ViewName: "",
 			Key:      gocui.KeyPgup,

--- a/pkg/gui/keybindings.go
+++ b/pkg/gui/keybindings.go
@@ -453,6 +453,13 @@ func (gui *Gui) GetInitialKeybindings() []*Binding {
 			Description: gui.Tr.Return,
 		},
 		{
+			ViewName:    "main",
+			Key:         'l',
+			Modifier:    gocui.ModNone,
+			Handler:     gui.handleMainViewLogsExternal,
+			Description: "View logs with external pager",
+		},
+		{
 			ViewName: "main",
 			Key:      gocui.KeyArrowLeft,
 			Modifier: gocui.ModNone,

--- a/pkg/gui/keybindings_test.go
+++ b/pkg/gui/keybindings_test.go
@@ -1,0 +1,75 @@
+package gui
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/jesseduffield/gocui"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTranslateKeybindingsToKorean(t *testing.T) {
+	inputBindings := []*Binding{
+		{
+			ViewName: "services",
+			Key:      's',
+			Modifier: gocui.ModNone,
+			Handler:  nil,
+		},
+		{
+			ViewName: "services",
+			Key:      'S',
+			Modifier: gocui.ModNone,
+			Handler:  nil,
+		},
+		{
+			ViewName: "services",
+			Key:      'l',
+			Modifier: gocui.ModNone,
+			Handler:  nil,
+		},
+		{
+			ViewName: "global",
+			Key:      gocui.KeyCtrlC,
+			Modifier: gocui.ModNone,
+			Handler:  nil,
+		},
+	}
+
+	result := translateKeybindingsToKorean(inputBindings)
+
+	// The original bindings must remain intact, and new ones should be appended
+	assert.Len(t, result, len(inputBindings)+3)
+
+	// Verify original bindings are still present and unaltered
+	for i, b := range inputBindings {
+		assert.Equal(t, b.Key, result[i].Key)
+		assert.Equal(t, b.Modifier, result[i].Modifier)
+	}
+
+	// Verify translated Korean bindings are appended correctly
+	// 's' -> 'ㄴ' (gocui.ModNone)
+	// 'S' -> 'ㄴ' (gocui.Modifier(tcell.ModShift))
+	// 'l' -> 'ㅣ' (gocui.ModNone)
+	
+	// We expect translated bindings to be appended:
+	foundS := false
+	foundShiftS := false
+	foundL := false
+
+	for _, b := range result[len(inputBindings):] {
+		if b.Key == 'ㄴ' && b.Modifier == gocui.ModNone {
+			foundS = true
+		}
+		if b.Key == 'ㄴ' && b.Modifier == gocui.Modifier(tcell.ModShift) {
+			foundShiftS = true
+		}
+		if b.Key == 'ㅣ' && b.Modifier == gocui.ModNone {
+			foundL = true
+		}
+	}
+
+	assert.True(t, foundS, "Expected to find translated Korean binding for 's'")
+	assert.True(t, foundShiftS, "Expected to find translated Korean binding for 'S'")
+	assert.True(t, foundL, "Expected to find translated Korean binding for 'l'")
+}

--- a/pkg/gui/main_panel.go
+++ b/pkg/gui/main_panel.go
@@ -2,6 +2,8 @@ package gui
 
 import (
 	"math"
+	"sync"
+	"time"
 
 	"github.com/jesseduffield/gocui"
 )
@@ -110,4 +112,85 @@ func (gui *Gui) handleMainClick() error {
 	}
 
 	return gui.switchFocus(gui.Views.Main)
+}
+
+var (
+	mouseTimerMutex sync.Mutex
+	mouseTimer      *time.Timer
+	mouseTicker     *time.Ticker
+	mouseTicksLeft  int
+)
+
+func (gui *Gui) handleToggleMouse() error {
+	mouseTimerMutex.Lock()
+	defer mouseTimerMutex.Unlock()
+
+	if gui.g.Mouse {
+		// Disable Mouse
+		gui.g.Mouse = false
+		gocui.Screen.DisableMouse()
+
+		if mouseTimer != nil {
+			mouseTimer.Stop()
+		}
+		if mouseTicker != nil {
+			mouseTicker.Stop()
+		}
+
+		mouseTicksLeft = 15
+		mouseTimer = time.AfterFunc(15*time.Second, func() {
+			gui.g.Update(func(g *gocui.Gui) error {
+				mouseTimerMutex.Lock()
+				defer mouseTimerMutex.Unlock()
+
+				if !gui.g.Mouse {
+					gui.g.Mouse = true
+					gocui.Screen.EnableMouse()
+					if mouseTicker != nil {
+						mouseTicker.Stop()
+					}
+					_ = gui.renderString(gui.g, "information", gui.getInformationContent())
+				}
+				return nil
+			})
+		})
+
+		mouseTicker = time.NewTicker(1 * time.Second)
+		go func() {
+			for range mouseTicker.C {
+				gui.g.Update(func(g *gocui.Gui) error {
+					mouseTimerMutex.Lock()
+					defer mouseTimerMutex.Unlock()
+
+					if gui.g.Mouse {
+						return nil
+					}
+					mouseTicksLeft--
+					if mouseTicksLeft <= 0 {
+						if mouseTicker != nil {
+							mouseTicker.Stop()
+						}
+						return nil
+					}
+					_ = gui.renderString(gui.g, "information", gui.getInformationContent())
+					return nil
+				})
+			}
+		}()
+
+	} else {
+		// Enable Mouse manually
+		gui.g.Mouse = true
+		gocui.Screen.EnableMouse()
+
+		if mouseTimer != nil {
+			mouseTimer.Stop()
+		}
+		if mouseTicker != nil {
+			mouseTicker.Stop()
+		}
+	}
+
+	_ = gui.renderString(gui.g, "information", gui.getInformationContent())
+	return nil
 }

--- a/pkg/gui/main_panel.go
+++ b/pkg/gui/main_panel.go
@@ -2,8 +2,6 @@ package gui
 
 import (
 	"math"
-	"sync"
-	"time"
 
 	"github.com/jesseduffield/gocui"
 )
@@ -112,85 +110,4 @@ func (gui *Gui) handleMainClick() error {
 	}
 
 	return gui.switchFocus(gui.Views.Main)
-}
-
-var (
-	mouseTimerMutex sync.Mutex
-	mouseTimer      *time.Timer
-	mouseTicker     *time.Ticker
-	mouseTicksLeft  int
-)
-
-func (gui *Gui) handleToggleMouse() error {
-	mouseTimerMutex.Lock()
-	defer mouseTimerMutex.Unlock()
-
-	if gui.g.Mouse {
-		// Disable Mouse
-		gui.g.Mouse = false
-		gocui.Screen.DisableMouse()
-
-		if mouseTimer != nil {
-			mouseTimer.Stop()
-		}
-		if mouseTicker != nil {
-			mouseTicker.Stop()
-		}
-
-		mouseTicksLeft = 15
-		mouseTimer = time.AfterFunc(15*time.Second, func() {
-			gui.g.Update(func(g *gocui.Gui) error {
-				mouseTimerMutex.Lock()
-				defer mouseTimerMutex.Unlock()
-
-				if !gui.g.Mouse {
-					gui.g.Mouse = true
-					gocui.Screen.EnableMouse()
-					if mouseTicker != nil {
-						mouseTicker.Stop()
-					}
-					_ = gui.renderString(gui.g, "information", gui.getInformationContent())
-				}
-				return nil
-			})
-		})
-
-		mouseTicker = time.NewTicker(1 * time.Second)
-		go func() {
-			for range mouseTicker.C {
-				gui.g.Update(func(g *gocui.Gui) error {
-					mouseTimerMutex.Lock()
-					defer mouseTimerMutex.Unlock()
-
-					if gui.g.Mouse {
-						return nil
-					}
-					mouseTicksLeft--
-					if mouseTicksLeft <= 0 {
-						if mouseTicker != nil {
-							mouseTicker.Stop()
-						}
-						return nil
-					}
-					_ = gui.renderString(gui.g, "information", gui.getInformationContent())
-					return nil
-				})
-			}
-		}()
-
-	} else {
-		// Enable Mouse manually
-		gui.g.Mouse = true
-		gocui.Screen.EnableMouse()
-
-		if mouseTimer != nil {
-			mouseTimer.Stop()
-		}
-		if mouseTicker != nil {
-			mouseTicker.Stop()
-		}
-	}
-
-	_ = gui.renderString(gui.g, "information", gui.getInformationContent())
-	return nil
 }

--- a/pkg/gui/services_panel.go
+++ b/pkg/gui/services_panel.go
@@ -333,6 +333,17 @@ func (gui *Gui) handleServiceRenderLogsToMain(g *gocui.Gui, v *gocui.View) error
 	return gui.runSubprocess(c)
 }
 
+func (gui *Gui) handleServiceViewLogsExternal(g *gocui.Gui, v *gocui.View) error {
+	service, err := gui.Panels.Services.GetSelectedItem()
+	if err != nil {
+		return nil
+	}
+	if service.Container == nil {
+		return gui.createErrorPanel("No container running for this service")
+	}
+	return gui.handleViewLogsExternal(service.Container)
+}
+
 func (gui *Gui) handleProjectUp(g *gocui.Gui, v *gocui.View) error {
 	project, _ := gui.Panels.Projects.GetSelectedItem()
 	if project != nil && project.Name != gui.DockerCommand.LocalProjectName {

--- a/pkg/gui/views.go
+++ b/pkg/gui/views.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/fatih/color"
@@ -195,6 +196,13 @@ func (gui *Gui) setInitialViewContent() error {
 
 func (gui *Gui) getInformationContent() string {
 	informationStr := gui.Config.Version
+
+	mouseStatus := "Mouse: ON"
+	if !gui.g.Mouse {
+		mouseStatus = fmt.Sprintf("Mouse: OFF (%ds left)", mouseTicksLeft)
+	}
+	informationStr = mouseStatus + " | " + informationStr
+
 	if !gui.g.Mouse {
 		return informationStr
 	}

--- a/pkg/gui/views.go
+++ b/pkg/gui/views.go
@@ -1,7 +1,6 @@
 package gui
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/fatih/color"
@@ -199,7 +198,7 @@ func (gui *Gui) getInformationContent() string {
 
 	mouseStatus := "Mouse: ON"
 	if !gui.g.Mouse {
-		mouseStatus = fmt.Sprintf("Mouse: OFF (%ds left)", mouseTicksLeft)
+		mouseStatus = "Mouse: OFF (Drag to copy)"
 	}
 	informationStr = mouseStatus + " | " + informationStr
 

--- a/pkg/utils/logs.go
+++ b/pkg/utils/logs.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	errRegex   = regexp.MustCompile(`(?i)\b(error|err|critical|fatal)\b`)
+	warnRegex  = regexp.MustCompile(`(?i)\b(warning|warn)\b`)
+	infoRegex  = regexp.MustCompile(`(?i)\b(info)\b`)
+	debugRegex = regexp.MustCompile(`(?i)\b(debug)\b`)
+
+	timestampRegex = regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\b`)
+)
+
+// ColoriseLog applies basic ANSI syntax highlighting to typical log statements.
+func ColoriseLog(line string) string {
+	if strings.Contains(line, "\x1b[") {
+		return line
+	}
+
+	line = timestampRegex.ReplaceAllStringFunc(line, func(ts string) string {
+		return "\x1b[90m" + ts + "\x1b[0m"
+	})
+
+	line = errRegex.ReplaceAllStringFunc(line, func(match string) string {
+		return "\x1b[31;1m" + match + "\x1b[0m"
+	})
+	line = warnRegex.ReplaceAllStringFunc(line, func(match string) string {
+		return "\x1b[33;1m" + match + "\x1b[0m"
+	})
+	line = infoRegex.ReplaceAllStringFunc(line, func(match string) string {
+		return "\x1b[32m" + match + "\x1b[0m"
+	})
+	line = debugRegex.ReplaceAllStringFunc(line, func(match string) string {
+		return "\x1b[34m" + match + "\x1b[0m"
+	})
+
+	return line
+}

--- a/pkg/utils/logs_test.go
+++ b/pkg/utils/logs_test.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestColoriseLog(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		contains []string
+	}{
+		{
+			name:     "Highlight error log level",
+			input:    "ERROR: database failed to connect",
+			contains: []string{"\x1b[31;1mERROR\x1b[0m"},
+		},
+		{
+			name:     "Highlight warning log level",
+			input:    "[WARN] deprecation warning",
+			contains: []string{"\x1b[33;1mWARN\x1b[0m"},
+		},
+		{
+			name:     "Highlight timestamp",
+			input:    "2026-06-04T12:00:00Z something happened",
+			contains: []string{"\x1b[90m2026-06-04T12:00:00Z\x1b[0m"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ColoriseLog(tt.input)
+			for _, c := range tt.contains {
+				if !strings.Contains(got, c) {
+					t.Errorf("expected %q to contain %q, but it was %q", got, c, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces several quality-of-life enhancements for container logs visibility, copying workflows, external pager integration, and layout compatibility.

### Key Changes
1. **Rule-Based Log Highlighting**:
   - Implemented a parser `ColoriseLog` in `pkg/utils/logs.go` to colorize common log levels (`INFO`, `WARN`, `ERROR`, `DEBUG`) and ISO timestamps using ANSI colors.
   - Wrapped `stderr` output in bold ANSI red to differentiate it from `stdout` stream data.
   
2. **Auto Mouse Capture Toggling (Drag to Copy)**:
   - When the main logs view focuses, mouse capture is automatically disabled (`gocui.Screen.DisableMouse()`) so users can immediately drag and select text for native copying.
   - Restores mouse capture automatically when focus leaves the main view to list panels.
   - Displays status info in the bottom panel (`Mouse: OFF (Drag to copy)`).

3. **External Pager Integration (`l` Key)**:
   - Binds `l` key inside logs, containers, and services views to suspend the TUI and launch an external log viewer/pager (defined in `config.yml` via `logs.pager`, default `less -R`).
   - Uses temporary file logging to pipe logs dynamically, avoiding terminal input conflicts/hangs.

4. **Korean Keyboard Layout Support**:
   - Added a dynamic keybinding translation hook for Korean 2-Set (Dubeolsik) keyboard layout.
   - Duplicates English bindings at runtime for Korean character inputs (e.g. mapping `ㄴ` to `s` and `ㄴ` + Shift to `S` / Start) to ensure the application works seamlessly when the IME is set to Korean.

### Testing
- Added unit tests for log colorizing in `pkg/utils/logs_test.go`.
- Added unit tests for keybinding translation mappings in `pkg/gui/keybindings_test.go`.
- Verified all unit and integration tests pass successfully.